### PR TITLE
docs: v0.2.0 planning roadmap and protocol analysis

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: Something is broken or behaving unexpectedly.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened and what was expected.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: How to trigger the bug.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Kubernetes version, cfgate version, cloudflare-go version.
+      value: |
+        - Kubernetes:
+        - cfgate:
+        - cloudflare-go:
+  - type: textarea
+    id: relevant-files
+    attributes:
+      label: Relevant Files
+      description: Paths to files involved.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,39 @@
+name: Feature
+description: Feature request or improvement to an existing system.
+labels: ["type/feature"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the feature or improvement. Include current state if modifying an existing system.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be built or changed.
+    validations:
+      required: true
+  - type: textarea
+    id: current-state
+    attributes:
+      label: Current State
+      description: What exists today, if anything. Leave blank for new features.
+  - type: textarea
+    id: remaining-work
+    attributes:
+      label: Remaining Work
+      description: Checklist of tasks to complete this feature.
+      value: |
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: relevant-files
+    attributes:
+      label: Relevant Files
+      description: Paths to files involved.
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Context, design considerations, or related issues.

--- a/docs/planning/v0.2.0-protocol-analysis.md
+++ b/docs/planning/v0.2.0-protocol-analysis.md
@@ -1,0 +1,401 @@
+# cfgate v0.2.0 Protocol and Product Analysis
+
+Technical reference for the networking protocols and Cloudflare products that inform cfgate v0.2.0 design decisions.
+
+## cloudflared Transport Architecture
+
+cloudflared uses **quic-go** (Go QUIC implementation) for tunnel transport and **Cap'n Proto** (capnp) for control plane RPC. It does not use quiche (Cloudflare's Rust QUIC library; separate project, different codebase).
+
+### Connection Model
+
+cloudflared opens up to 4 high-availability connections to different Cloudflare edge servers. Each connection follows this sequence:
+
+1. DNS resolution of `protocol-v2.argotunnel.com` returns edge server IPs
+2. `DialQuic()` creates a UDP socket bound to a specific local port per connection index
+3. TLS handshake uses SNI `quic.cftunnel.com` with ALPN `argotunnel`
+4. On success, cloudflared wraps the `quic.Connection` to ensure the UDP socket closes with the QUIC connection
+
+Source: `cloudflared/connection/quic.go:21-89`
+
+### Stream Multiplexing
+
+Each QUIC connection carries three types of traffic:
+
+```mermaid
+graph LR
+    subgraph "QUIC Connection (UDP:7844)"
+        CS[Control Stream<br/>capnp RPC<br/>Registration, config push]
+        DS[Data Streams<br/>HTTP, WebSocket, TCP<br/>Edge-initiated]
+        DG[QUIC Datagrams<br/>UDP sessions, ICMP<br/>Unreliable delivery]
+    end
+```
+
+- **Control stream**: First QUIC stream, opened by cloudflared. Carries tunnel registration (`RegisterConnection`) and configuration updates (`UpdateConfiguration`) via capnp RPC.
+- **Data streams**: Opened by the edge toward cloudflared. Each starts with a 6-byte protocol signature (`0x0A36CD12A13E` for data, `0x52BB825CDB65` for RPC) followed by a capnp `ConnectRequest`.
+- **QUIC datagrams**: RFC 9221 unreliable delivery. Used for UDP session payloads, ICMP packets, and UDP session registration (v3 protocol).
+
+Source: `cloudflared/connection/quic_connection.go:87-143`
+
+### Protocol Selection
+
+| Mode | Flag | Behavior |
+|------|------|----------|
+| auto | `--protocol auto` (default) | QUIC with HTTP/2 fallback |
+| quic | `--protocol quic` | Force QUIC; required for post-quantum |
+| http2 | `--protocol http2` | Force HTTP/2; required for gRPC trailer support |
+
+The `--protocol` flag is passed as a container argument in cloudflared Deployments. cfgate sets this via `CloudflareTunnelSpec.Cloudflared.Protocol`.
+
+Source: `cloudflared/connection/protocol.go:203-248`
+
+### Tunnel Establishment Sequence
+
+```mermaid
+sequenceDiagram
+    participant cfd as cloudflared
+    participant dns as DNS
+    participant edge as CF Edge
+
+    cfd->>dns: Resolve protocol-v2.argotunnel.com
+    dns-->>cfd: Edge IPs (SRV records)
+
+    loop For each HA connection (0..3)
+        cfd->>edge: QUIC handshake (UDP:7844)<br/>SNI: quic.cftunnel.com, ALPN: argotunnel
+        edge-->>cfd: QUIC connection established
+
+        cfd->>edge: Open control stream
+        cfd->>edge: [RPC signature] capnp RegisterConnection<br/>(TunnelAuth, tunnelID, connIndex)
+        edge-->>cfd: capnp ConnectionResponse<br/>(UUID, colo, remote-managed flag)
+
+        par Data Streams
+            edge->>cfd: [data signature] ConnectRequest(type, dest)
+            cfd-->>edge: ConnectResponse + proxied payload
+        and QUIC Datagrams
+            edge->>cfd: UDP/ICMP datagram frames (v3)
+            cfd-->>edge: UDP/ICMP datagram frames (v3)
+        end
+    end
+```
+
+## Cap'n Proto RPC
+
+### Why capnp
+
+cloudflared uses `zombiezen.com/go/capnproto2` v2.18.0 for serialization and RPC. Advantages over protobuf/gRPC for this use case:
+
+- Zero-copy deserialization (wire format = memory format)
+- Capability-based RPC with object references passed across the wire
+- Stream-oriented transport fits the QUIC stream model
+- Historical choice from early Cloudflare Tunnel architecture
+
+### Schema
+
+Two capnp schemas define the tunnel protocol:
+
+**tunnelrpc.capnp** (control plane):
+```
+RegistrationServer
+  RegisterConnection(auth, tunnelId, connIndex, options) -> ConnectionResponse
+  UnregisterConnection()
+  UpdateLocalConfiguration(config)
+
+CloudflaredServer extends(SessionManager, ConfigurationManager)
+
+SessionManager
+  RegisterUdpSession(sessionId, dstIp, dstPort, closeAfterIdleHint, traceContext)
+  UnregisterUdpSession(sessionId, message)
+
+ConfigurationManager
+  UpdateConfiguration(version, config) -> UpdateConfigurationResponse
+```
+
+**quic_metadata_protocol.capnp** (data plane framing):
+```
+ConnectRequest { dest: Text, type: ConnectionType, metadata: List(Metadata) }
+ConnectResponse { error: Text, metadata: List(Metadata) }
+```
+
+Source: `cloudflared/tunnelrpc/proto/tunnelrpc.capnp:165-193`, `cloudflared/tunnelrpc/proto/quic_metadata_protocol.capnp:1-28`
+
+### Configuration Push Flow
+
+```mermaid
+graph TD
+    A[CF Dashboard or API<br/>PUT /cfd_tunnel/id/configurations] --> B[CF Control Plane]
+    B --> C[CF Edge]
+    C -->|capnp RPC: UpdateConfiguration| D[cloudflared]
+    D --> E[Orchestrator.UpdateConfig]
+    E --> F[Parse JSON, update ingress rules]
+```
+
+The config JSON pushed via capnp `UpdateConfiguration` is the same JSON structure as the tunnel config API. Undocumented fields (`h2cOrigin`, `warp-routing`) are preserved and parsed by cloudflared's config parser.
+
+## HTTP/2 vs HTTP/3 Semantics
+
+### Edge-to-cloudflared Transport
+
+These are the transport protocols between cloudflared and the Cloudflare edge. They are not the protocols between the end user and the edge (which is HTTP/1.1, HTTP/2, or HTTP/3 depending on the client).
+
+| Transport | Underlying | Trailer Support |
+|-----------|------------|-----------------|
+| HTTP/2 | TCP + TLS | Yes (Go `http2.TrailerPrefix`) |
+| QUIC | UDP + TLS 1.3 (quic-go) | No (silently dropped) |
+
+### The gRPC Trailer Problem
+
+gRPC encodes `grpc-status` and `grpc-message` in HTTP/2 trailers. The QUIC transport's `httpResponseAdapter.AddTrailer()` is a no-op:
+
+```go
+func (hrw *httpResponseAdapter) AddTrailer(trailerName, trailerValue string) {
+    hrw.logger.Warn().Str("trailerName", trailerName).
+        Msg("QUIC transport does not support trailers; trailer will be dropped. " +
+            "For gRPC origins, use --protocol http2 to enable trailer support")
+}
+```
+
+Source: `cloudflared/connection/quic_connection.go:287-293`
+
+The HTTP/2 transport preserves trailers via `http2RespWriter.AddTrailer()`:
+
+Source: `cloudflared/connection/http2.go:229-236`
+
+### Consequences for cfgate
+
+| Route Type | Tunnel Protocol | gRPC Support |
+|------------|----------------|--------------|
+| HTTPRoute | QUIC (default) | N/A |
+| GRPCRoute | QUIC | Trailers dropped; status codes lost |
+| GRPCRoute | HTTP/2 | Trailers preserved; full gRPC support |
+| TCPRoute (private) | QUIC datagrams | N/A (L4 passthrough) |
+
+cfgate must detect GRPCRoute attachment and either:
+- Force `--protocol http2` on the cloudflared Deployment, or
+- Emit a warning event documenting the limitation
+
+## WireGuard and WARP
+
+### Architecture
+
+WARP is Cloudflare's client-side agent. It establishes an encrypted tunnel from end-user devices to the Cloudflare edge using WireGuard (or MASQUE for newer deployments).
+
+WARP maintains three persistent connections:
+
+1. **WARP tunnel** (WireGuard over UDP): IP packets for network policy and private network access
+2. **DoH connection** (HTTPS): DNS requests routed within the WARP tunnel
+3. **Device orchestration** (HTTPS): Registration, posture checks, profile application
+
+Source: [WARP architecture docs](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/warp-architecture/)
+
+### Private Network Traffic Flow
+
+```mermaid
+graph LR
+    A[WARP Client<br/>10.0.1.5:5432] -->|WireGuard/UDP| B[CF Edge]
+    B -->|Route lookup:<br/>10.0.1.0/24 -> tunnel-xyz| C[cloudflared Pod]
+    C -->|TCP or UDP proxy| D[Private Service<br/>10.0.1.5:5432]
+```
+
+1. WARP client encapsulates IP packets in WireGuard
+2. CF edge decapsulates and performs route lookup against configured CIDR routes
+3. Edge locates the tunnel associated with the matching route
+4. Edge sends traffic to cloudflared via QUIC (streams for TCP, datagrams for UDP/ICMP)
+5. cloudflared proxies to the private origin
+
+### WARP Connector
+
+WARP Connector runs on a Linux machine (typically the default gateway) and establishes a L3 WireGuard tunnel to Cloudflare. Other devices on the network do not need WARP installed. Relevant for cfgate because WARP Connector could run as a Kubernetes DaemonSet for site-level private network connectivity.
+
+Source: [WARP Connector docs](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/warp-connector/)
+
+## TCP/UDP Proxying Through Tunnels
+
+### Two Models
+
+#### Model 1: Public Hostname Ingress (L7 Wrapping)
+
+TCP services exposed via public hostnames. The edge wraps TCP connections in HTTP streams with `Cf-Cloudflared-Proxy-Src` header. Requires DNS record and Access policy. Does not support raw UDP.
+
+Ingress rule format:
+```json
+{
+  "hostname": "ssh.example.com",
+  "service": "tcp://10.0.0.5:22"
+}
+```
+
+#### Model 2: WARP Routing (L3/L4 Native)
+
+Private network traffic from WARP clients at L3/L4:
+
+- **TCP**: Edge opens QUIC stream with `ConnectionTypeTCP`. cloudflared's `ProxyTCP()` connects to origin and bidirectionally copies bytes.
+- **UDP**: Edge sends QUIC datagrams. cloudflared opens local UDP socket and bidirectionally copies datagrams. Datagram v3 protocol with binary framing.
+- **ICMP**: Edge sends QUIC datagrams with ICMP type. Automatic when WARP routing is active.
+
+Source: `cloudflared/connection/quic_connection.go:220-247`
+
+### Datagram V3 Protocol
+
+The current datagram multiplexing format (replacing the legacy v2 capnp-based registration):
+
+| Type Byte | Name | Purpose |
+|-----------|------|---------|
+| `0x0` | UDPSessionRegistration | Register a new UDP session |
+| `0x1` | UDPSessionPayload | Proxy UDP payload |
+| `0x2` | ICMP | Proxy ICMP packet |
+| `0x3` | UDPSessionRegistrationResponse | Registration result |
+
+Source: `cloudflared/quic/v3/datagram.go:11-19`
+
+### WarpRoutingConfig (cloudflared)
+
+```go
+type WarpRoutingConfig struct {
+    ConnectTimeout *CustomDuration
+    MaxActiveFlows *uint64
+    TCPKeepAlive   *CustomDuration
+}
+```
+
+- `MaxActiveFlows`: Limits concurrent UDP/TCP sessions across the tunnel
+- `ConnectTimeout`: Timeout for establishing TCP connections to origins
+- `TCPKeepAlive`: TCP keepalive interval for proxied connections
+
+The `warp-routing.enabled` boolean is deprecated. WARP routing traffic is proxied whenever routes are configured for the tunnel.
+
+Source: `cloudflared/config/configuration.go:265-269`, `cloudflared/CHANGES.md:38`
+
+### Key Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| MaxActiveFlows | (unlimited) | Concurrent session limit |
+| ConnectTimeout | 30s | TCP connection timeout to origin |
+| TCPKeepAlive | 30s | Keepalive interval |
+| Max UDP payload | 1280 bytes | Pre-MTU discovery limit |
+| Session idle timeout | 210s | Configurable per session |
+
+## Cloudflare Product Mapping
+
+### What cfgate Can Configure via API
+
+| Resource | API Endpoint | cfgate Action |
+|----------|-------------|---------------|
+| Tunnel | POST /accounts/{id}/cfd_tunnel | Create, delete |
+| Tunnel config | PUT /accounts/{id}/cfd_tunnel/{tid}/configurations | Ingress rules, origin settings, WARP routing |
+| DNS record | Standard DNS API | CNAME to tunnel |
+| Tunnel route | POST /accounts/{id}/teamnet/routes | Register CIDR ranges for WARP routing |
+| Virtual network | POST /accounts/{id}/teamnet/virtual_networks | Create/manage overlapping IP spaces |
+| Access application | Access API | App + policies for public services |
+
+### What Is cloudflared Runtime (Not API-Configurable)
+
+| Behavior | Where | Notes |
+|----------|-------|-------|
+| QUIC transport parameters | Compiled into quic-go fork | MTU, congestion, keepalive |
+| capnp RPC protocol | Hard-coded in binary | Registration, session management |
+| Datagram v2/v3 selection | Feature flag from edge | Not operator-configurable |
+| HA connection count | CLI flag `--ha-connections` | Exposed as container arg |
+| Protocol selection | CLI flag `--protocol` | cfgate can set per-tunnel |
+| Post-quantum mode | CLI flag `--post-quantum` | cfgate can enable per-tunnel |
+
+### Protocol Layer Summary
+
+```
+Layer         What                      Who Controls              cfgate Role
+---------------------------------------------------------------------------
+L7 HTTP       Ingress rules             CF API (tunnel config)    Full control
+L7 gRPC       Trailers, status          Transport protocol        Protocol selection
+L4 TCP        WARP routing              CF API (routes)           Route management
+L4 UDP        WARP routing + datagrams  CF API (routes)           Route management
+L3 ICMP       WARP routing + datagrams  cloudflared runtime       Indirect (via routes)
+Transport     QUIC/HTTP2                cloudflared CLI flag      Container args
+Control       capnp RPC                 cloudflared binary        Not configurable
+```
+
+## SDK Coverage
+
+cfgate uses `github.com/cloudflare/cloudflare-go/v6 v6.6.0`.
+
+| Feature | SDK Service | Typed Methods | Workaround |
+|---------|-------------|---------------|------------|
+| Tunnel CRUD | `Tunnels.Cloudflared` | Yes | None |
+| Tunnel config (ingress) | `Tunnels.Cloudflared.Configurations` | Yes | None |
+| Tunnel config (warp-routing) | `Tunnels.Cloudflared.Configurations` | Not in schema | `option.WithJSONSet()` |
+| Network routes CRUD | `Networks.Routes` | Yes (5 methods) | None |
+| Virtual networks CRUD | `Networks.VirtualNetworks` | Yes (5 methods) | None |
+| DNS records | `DNS.Records` | Yes | None |
+| Access apps/policies | `ZeroTrust.Access` | Yes | None |
+
+### Route API Types (cloudflare-go v6)
+
+```go
+// Create
+type NetworkRouteNewParams struct {
+    AccountID        param.Field[string]  // required
+    Network          param.Field[string]  // required, CIDR
+    TunnelID         param.Field[string]  // required
+    Comment          param.Field[string]  // optional
+    VirtualNetworkID param.Field[string]  // optional
+}
+
+// Response
+type Route struct {
+    ID               string    `json:"id"`
+    Network          string    `json:"network"`
+    TunnelID         string    `json:"tunnel_id"`
+    VirtualNetworkID string    `json:"virtual_network_id"`
+    Comment          string    `json:"comment"`
+    CreatedAt        time.Time `json:"created_at"`
+    DeletedAt        time.Time `json:"deleted_at"`
+}
+```
+
+## Free Tier Feature Map
+
+All v0.2.0 features operate within the Zero Trust free plan:
+
+| Feature | Available | Limit |
+|---------|-----------|-------|
+| Cloudflare Tunnel | Yes | No documented tunnel limit |
+| WARP routing | Yes | 50 enrolled users |
+| Tunnel routes (CIDR) | Yes | No documented route limit |
+| Virtual networks | Yes | No documented vnet limit |
+| Access policies | Yes | 50 users |
+| Spectrum (L4 DDoS proxy) | No | Pro+ required |
+
+The 50-user WARP enrollment limit is the primary constraint. Beyond 50 users, Teams Standard ($7/seat/month) is required.
+
+## Sources
+
+### Cloudflare Documentation
+- [Connect a private network (CIDR)](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-cidr/)
+- [WARP architecture](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/warp-architecture/)
+- [Virtual networks](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/tunnel-virtual-networks/)
+- [gRPC connections](https://developers.cloudflare.com/network/grpc-connections/)
+- [HTTP/3 docs](https://developers.cloudflare.com/speed/optimization/protocol/http3/)
+- [Tunnel routes API](https://developers.cloudflare.com/api/resources/zero_trust/subresources/networks/subresources/routes/)
+- [Virtual networks API](https://developers.cloudflare.com/api/resources/zero_trust/subresources/networks/subresources/virtual_networks/)
+
+### Cloudflare Blog
+- [Getting Cloudflare Tunnels to connect with QUIC](https://blog.cloudflare.com/getting-cloudflare-tunnels-to-connect-to-the-cloudflare-network-with-quic/)
+- [Road to gRPC](https://blog.cloudflare.com/road-to-grpc/)
+- [Build your own private network on Cloudflare](https://blog.cloudflare.com/build-your-own-private-network-on-cloudflare/)
+- [WARP to WARP](https://blog.cloudflare.com/warp-to-warp/)
+- [Post-quantum Cloudflare Tunnel](https://blog.cloudflare.com/post-quantum-tunnel/)
+
+### cloudflared Source (inherent-design fork)
+- `go.mod:25,46,102-103`: quic-go and capnp dependencies
+- `connection/quic.go:21-89`: QUIC connection establishment
+- `connection/protocol.go:14-254`: Protocol selection logic
+- `connection/quic_connection.go:42-447`: QUIC stream and datagram handling
+- `connection/http2.go:26-435`: HTTP/2 transport implementation
+- `tunnelrpc/proto/tunnelrpc.capnp:1-193`: Tunnel RPC schema
+- `tunnelrpc/proto/quic_metadata_protocol.capnp:1-28`: Data stream framing
+- `tunnelrpc/quic/protocol.go:1-78`: Stream signature discrimination
+- `quic/v3/datagram.go:1-433`: Datagram v3 binary protocol
+- `quic/v3/session.go:1-352`: UDP session implementation
+- `config/configuration.go:257-269`: WarpRoutingConfig struct
+
+### GitHub Issues
+- [cloudflared #226: HTTP/2 tunnel limitations](https://github.com/cloudflare/cloudflared/issues/226)
+- [cloudflared #688: QUIC default protocol](https://github.com/cloudflare/cloudflared/issues/688)

--- a/docs/planning/v0.2.0-roadmap.md
+++ b/docs/planning/v0.2.0-roadmap.md
@@ -1,0 +1,404 @@
+# cfgate v0.2.0 Roadmap
+
+L4 routing, WARP private networks, and GRPCRoute support.
+
+## Scope
+
+v0.2.0 adds three new Gateway API route controllers (GRPCRoute, TCPRoute, UDPRoute), WARP routing for private network access, and tunnel route management for CIDR-to-tunnel mapping. All features operate within the Cloudflare Zero Trust free tier (50 users).
+
+### In Scope
+
+| Feature | Gateway API Resource | Cloudflare Mechanism |
+|---------|---------------------|---------------------|
+| gRPC routing | GRPCRoute (v1) | Ingress rules with h2c origin |
+| TCP routing (public) | TCPRoute (v1alpha2) | Ingress rules with `tcp://` service URL |
+| TCP routing (private) | TCPRoute (v1alpha2) | WARP routing + CIDR tunnel routes |
+| UDP routing (private) | UDPRoute (v1alpha2) | WARP routing + CIDR tunnel routes |
+| Private network CIDRs | N/A (operator-managed) | Tunnel Routes API |
+| Virtual network isolation | N/A (operator-managed) | Virtual Networks API |
+
+### Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Spectrum (L4 DDoS proxy) | Pro+ plan required; $1/GB overage |
+| WARP client/split tunnel management | Device-level policy, not tunnel-level |
+| Gateway DNS/HTTP policies | Separate concern; future scope |
+| CloudflarePrivateNetwork CRD | Deferred to v0.3.0 for static CIDR management |
+
+## Architecture Decisions
+
+### ADR-1: WARP Routing Over Spectrum for L4
+
+**Context:** The v0.1.0 TCPRoute/UDPRoute stubs reference Spectrum integration. Spectrum is an enterprise-only paid L4 proxy service.
+
+**Decision:** Use WARP routing through tunnels for L4 traffic instead of Spectrum. WARP routing is free tier, handles TCP and UDP, and is already partially wired in cfgate (WarpRoutingConfig exists in client.go and configmap.go).
+
+**Consequences:**
+- L4 routing requires WARP client enrollment on connecting devices (not public internet-facing)
+- cfgate manages tunnel routes (CIDR mappings) via the Cloudflare API
+- Public TCP services still use ingress rules with `tcp://` service URLs and Access policies
+- 50-user WARP limit on free tier; Teams Standard ($7/seat/month) for more
+
+### ADR-2: Extend CloudflareTunnel CRD (Not New CRD)
+
+**Context:** WARP routing configuration could live on the existing CloudflareTunnel CRD or a new CloudflarePrivateNetwork CRD.
+
+**Decision:** Add `WarpRoutingSpec` to CloudflareTunnelSpec for v0.2.0. Defer CloudflarePrivateNetwork to v0.3.0.
+
+**Consequences:**
+- Minimal CRD surface area in v0.2.0 (already adding 3 controllers)
+- CIDR routes created/deleted by TCPRoute/UDPRoute controllers, not the tunnel controller
+- Tunnel controller enables `warp-routing.enabled` when any L4 route targets it
+- v0.3.0 introduces the separate CRD for static routes and multi-tunnel mesh
+
+### ADR-3: GRPCRoute Requires HTTP/2 Transport
+
+**Context:** cloudflared's QUIC transport drops HTTP/2 trailers silently. gRPC encodes status codes in trailers. The HTTP/2 transport preserves trailers.
+
+**Decision:** GRPCRoute controller auto-sets `h2cOrigin: true` on generated ingress rules and documents that `--protocol http2` may be required for gRPC reliability. Emit warning events about trailer/streaming limitations on QUIC transport.
+
+**Consequences:**
+- gRPC through Cloudflare Tunnel works reliably only with HTTP/2 transport
+- cfgate should annotate or configure protocol selection per tunnel when GRPCRoute is attached
+- Server streaming works; bidirectional streaming may have issues on QUIC
+- This is a cloudflared architecture constraint, not fixable by cfgate
+
+**Sources:**
+- `cloudflared/connection/quic_connection.go:287-293` (trailer no-op on QUIC)
+- `cloudflared/connection/http2.go:229-236` (trailer support on HTTP/2)
+- [Cloudflare Road to gRPC](https://blog.cloudflare.com/road-to-grpc/)
+
+### ADR-4: TCP Dual-Path (Public + Private)
+
+**Context:** TCPRoute can route traffic two ways: public hostname ingress (with Access authentication) or private WARP routing (with CIDR routes).
+
+**Decision:** Support both paths. Public TCP uses ingress rules with `tcp://` service URLs. Private TCP uses WARP routing with CIDR tunnel routes. The path is determined by whether the route has a `cfgate.io/hostname` annotation (public) or not (private, CIDR-based).
+
+**Consequences:**
+- Public TCP: DNS record + Access policy + ingress rule (similar to HTTPRoute)
+- Private TCP: CIDR route + WARP routing enablement (no DNS, no Access)
+- Annotation-driven routing decision keeps the Gateway API resource clean
+
+## Controller Topology
+
+```mermaid
+graph TD
+    subgraph "Gateway API Resources"
+        GC[GatewayClass]
+        GW[Gateway]
+        HR[HTTPRoute]
+        TR[TCPRoute v1alpha2]
+        UR[UDPRoute v1alpha2]
+        GR[GRPCRoute v1]
+    end
+
+    subgraph "cfgate CRDs"
+        CT[CloudflareTunnel]
+        CD[CloudflareDNS]
+        CA[CloudflareAccessPolicy]
+    end
+
+    subgraph "Controllers"
+        GCC[GatewayClassReconciler]
+        GWC[GatewayReconciler]
+        HRC[HTTPRouteReconciler]
+        TRC["TCPRouteReconciler (new)"]
+        URC["UDPRouteReconciler (new)"]
+        GRC["GRPCRouteReconciler (new)"]
+        CTC[CloudflareTunnelReconciler]
+        CDC[CloudflareDNSReconciler]
+        CAC[CloudflareAccessPolicyReconciler]
+    end
+
+    subgraph "Cloudflare API"
+        TUN[Tunnel Config API]
+        DNS[DNS API]
+        ACC[Access API]
+        RTE["Tunnel Routes API (new)"]
+        VNT["Virtual Networks API (new)"]
+    end
+
+    GCC --> GC
+    GWC --> GW
+    GWC --> CT
+    HRC --> HR
+    TRC --> TR
+    URC --> UR
+    GRC --> GR
+
+    CTC --> TUN
+    CTC -.->|collects rules from| HR
+    CTC -.->|collects rules from| GR
+    CTC -.->|enables WARP routing if| TR
+    CTC -.->|enables WARP routing if| UR
+
+    TRC --> RTE
+    URC --> RTE
+
+    CDC --> DNS
+    CAC --> ACC
+```
+
+## Data Flow: L4 Route Reconciliation
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant K8s as Kubernetes API
+    participant TRC as TCPRouteReconciler
+    participant CTC as TunnelReconciler
+    participant CF as Cloudflare API
+
+    User->>K8s: Create TCPRoute (private)
+    K8s->>TRC: Reconcile TCPRoute
+    TRC->>K8s: Validate parentRef (Gateway -> GatewayClass)
+    TRC->>K8s: Resolve backend Service (ClusterIP:port)
+    TRC->>K8s: Get tunnel via Gateway tunnel-ref annotation
+    TRC->>CF: POST /accounts/{id}/teamnet/routes<br/>(network: service CIDR, tunnel_id: tunnel UUID)
+    TRC->>K8s: Update TCPRoute status (TunnelRouteCreated)
+    K8s->>CTC: Reconcile Tunnel (watch triggered)
+    CTC->>CTC: Detect TCPRoute exists for this tunnel
+    CTC->>CF: PUT tunnel config (warp-routing.enabled: true)
+```
+
+## WARP Routing Data Path
+
+```mermaid
+sequenceDiagram
+    participant warp as WARP Client
+    participant edge as CF Edge
+    participant cfd as cloudflared
+    participant origin as Private Origin
+
+    Note over warp: User accesses 10.0.1.5:5432
+
+    warp->>edge: WireGuard packet (IP: 10.0.1.5, port: 5432)
+    edge->>edge: Route lookup: 10.0.1.0/24 -> tunnel-xyz
+
+    alt TCP Connection
+        edge->>cfd: QUIC stream [data sig] ConnectRequest(tcp, 10.0.1.5:5432)
+        cfd->>origin: TCP connect 10.0.1.5:5432
+        origin-->>cfd: TCP accept
+        cfd-->>edge: ConnectResponse(ok)
+        Note over edge,origin: Bidirectional byte copy
+    else UDP Session
+        edge->>cfd: QUIC datagram [UDPSessionRegistration] dest=10.0.1.5:5432
+        cfd->>origin: UDP bind local socket
+        cfd-->>edge: [UDPSessionRegistrationResponse] ok
+        loop Session active
+            edge->>cfd: [UDPSessionPayload] data
+            cfd->>origin: UDP send
+            origin-->>cfd: UDP recv
+            cfd-->>edge: [UDPSessionPayload] data
+        end
+    end
+```
+
+## Implementation Phases
+
+### Phase 1: Foundation
+
+Prerequisite for all new controllers. No user-facing changes.
+
+| Task | Files | Description |
+|------|-------|-------------|
+| Client interface expansion | client.go, client_impl.go | Add TunnelRoute (5 methods) and VirtualNetwork (5 methods) groups |
+| TunnelRouteService | cloudflare/tunnel_route.go (new) | EnsureRoute, DeleteRoute, ListRoutesForTunnel |
+| Scheme registration | cmd/manager/main.go | `gwapiv1alpha2.Install(scheme)` |
+| Gateway SupportedKinds | gateway_controller.go | Dynamic kinds based on listener protocol + feature gates |
+| FeatureGates injection | gateway_controller.go | Pass FeatureGates to GatewayReconciler |
+
+### Phase 2: GRPCRoute
+
+Lowest risk; same ingress-rule mechanism as HTTPRoute. Validates the pattern before L4 work.
+
+| Task | Files | Description |
+|------|-------|-------------|
+| GRPCRouteReconciler | grpcroute_controller.go (new) | Follow HTTPRoute pattern; auto-set h2cOrigin |
+| Tunnel integration | cloudflaretunnel_controller.go | Extend collectIngressRules for GRPCRoute |
+| Tunnel watches | cloudflaretunnel_controller.go | Add GRPCRoute watch + mapper |
+| Feature gate registration | cmd/manager/main.go | Conditional GRPCRoute controller registration |
+
+### Phase 3: TCPRoute + WARP Routing
+
+Exercises the WARP routing path. Public hostname TCP uses ingress rules; private TCP uses CIDR routes.
+
+| Task | Files | Description |
+|------|-------|-------------|
+| TCPRouteReconciler | tcproute_controller.go (rewrite) | Full implementation replacing stub |
+| WARP routing toggle | cloudflaretunnel_controller.go, configmap.go | Enable warp-routing when L4 routes exist |
+| Tunnel route lifecycle | tcproute_controller.go | Create/delete CIDR routes on reconcile |
+| Feature gate registration | cmd/manager/main.go | Conditional TCPRoute controller registration |
+
+### Phase 4: UDPRoute
+
+Same pattern as TCPRoute private path. UDP-only (no public hostname without Spectrum).
+
+| Task | Files | Description |
+|------|-------|-------------|
+| UDPRouteReconciler | udproute_controller.go (rewrite) | Full implementation replacing stub |
+| Feature gate registration | cmd/manager/main.go | Conditional UDPRoute controller registration |
+
+### Phase 5: Integration and Testing
+
+| Task | Files | Description |
+|------|-------|-------------|
+| E2E: GRPCRoute | test/e2e/grpcroute_test.go (new) | gRPC routing tests |
+| E2E: TCPRoute | test/e2e/tcproute_test.go (new) | TCP routing tests (public + private) |
+| E2E: UDPRoute | test/e2e/udproute_test.go (new) | UDP routing tests (private only) |
+| CRD validation | api/v1alpha1/cloudflaretunnel_types.go | CEL rules for WarpRoutingSpec |
+| Documentation | docs/ | L4 routing guide, GRPCRoute guide, annotation updates |
+
+## File Change Manifest
+
+| File | Change | Phase |
+|------|--------|-------|
+| `cmd/manager/main.go` | Modify: add v1alpha2 scheme, conditional registration | 1 |
+| `internal/cloudflare/client.go` | Modify: add TunnelRoute + VirtualNetwork types and methods | 1 |
+| `internal/cloudflare/client_impl.go` | Modify: implement new Client methods | 1 |
+| `internal/cloudflare/tunnel_route.go` | New: TunnelRouteService | 1 |
+| `internal/controller/gateway_controller.go` | Modify: dynamic SupportedKinds, FeatureGates | 1 |
+| `internal/controller/grpcroute_controller.go` | New: GRPCRouteReconciler | 2 |
+| `internal/controller/cloudflaretunnel_controller.go` | Modify: extend collectIngressRules, add watches, WARP toggle | 2, 3 |
+| `internal/cloudflared/configmap.go` | Modify: set WarpRouting.Enabled | 3 |
+| `internal/controller/tcproute_controller.go` | Rewrite: full implementation | 3 |
+| `internal/controller/udproute_controller.go` | Rewrite: full implementation | 4 |
+| `internal/controller/annotations/annotations.go` | Modify: add virtual-network annotation | 3 |
+| `internal/controller/status/conditions.go` | Modify: add TunnelRouteCreated condition | 3 |
+| `api/v1alpha1/cloudflaretunnel_types.go` | Modify: add WarpRoutingSpec | 3 |
+| `config/crd/bases/` | Auto-generated via codegen | 3 |
+| `config/rbac/role.yaml` | Auto-generated via codegen | 2 |
+
+## CRD Changes
+
+### CloudflareTunnel: New WarpRoutingSpec
+
+```yaml
+apiVersion: cfgate.io/v1alpha1
+kind: CloudflareTunnel
+metadata:
+  name: prod-tunnel
+spec:
+  # ... existing fields ...
+  warpRouting:
+    enabled: true
+    virtualNetworkRef: "production"  # optional
+```
+
+Go types:
+
+```go
+type WarpRoutingSpec struct {
+    // Enabled enables WARP routing for this tunnel. Automatically set
+    // to true if any TCPRoute or UDPRoute targets this tunnel.
+    // +kubebuilder:default=false
+    Enabled bool `json:"enabled,omitempty"`
+
+    // VirtualNetworkRef references a virtual network for overlapping CIDR
+    // isolation. If unset, routes are assigned to the default virtual network.
+    // +optional
+    VirtualNetworkRef string `json:"virtualNetworkRef,omitempty"`
+}
+```
+
+### New Client Interface Methods
+
+```go
+// Tunnel Route operations
+ListTunnelRoutes(ctx context.Context, accountID string, params ListTunnelRoutesParams) ([]TunnelRoute, error)
+GetTunnelRoute(ctx context.Context, accountID, routeID string) (*TunnelRoute, error)
+CreateTunnelRoute(ctx context.Context, accountID string, params CreateTunnelRouteParams) (*TunnelRoute, error)
+UpdateTunnelRoute(ctx context.Context, accountID, routeID string, params UpdateTunnelRouteParams) (*TunnelRoute, error)
+DeleteTunnelRoute(ctx context.Context, accountID, routeID string) error
+
+// Virtual Network operations
+ListVirtualNetworks(ctx context.Context, accountID string) ([]VirtualNetwork, error)
+GetVirtualNetwork(ctx context.Context, accountID, vnetID string) (*VirtualNetwork, error)
+CreateVirtualNetwork(ctx context.Context, accountID string, params CreateVirtualNetworkParams) (*VirtualNetwork, error)
+UpdateVirtualNetwork(ctx context.Context, accountID, vnetID string, params UpdateVirtualNetworkParams) (*VirtualNetwork, error)
+DeleteVirtualNetwork(ctx context.Context, accountID, vnetID string) error
+```
+
+SDK mapping: Both are fully typed in cloudflare-go v6.6.0 (`NetworkRouteService`, `NetworkVirtualNetworkService`). No `WithJSONSet` workarounds needed for route CRUD. The `warp-routing.enabled` tunnel config field still requires `option.WithJSONSet()`.
+
+## Constraints and Limitations
+
+### Protocol Constraints
+
+| Constraint | Impact | Mitigation |
+|------------|--------|------------|
+| QUIC transport drops HTTP/2 trailers | gRPC `grpc-status` lost | Force `--protocol http2` for GRPCRoute tunnels |
+| UDP max datagram payload: 1280 bytes | Large UDP packets fragmented | Document; applications must handle MTU |
+| `warp-routing.enabled` deprecated | Routes alone trigger traffic flow | Manage route lifecycle carefully |
+| MaxActiveFlows limits concurrent sessions | Capacity planning needed | Expose as CloudflareTunnel spec field |
+
+### Free Tier Constraints
+
+| Constraint | Limit | Upgrade Path |
+|------------|-------|-------------|
+| WARP user enrollment | 50 seats | Teams Standard ($7/seat/month) |
+| L4 public proxy (Spectrum) | Not available | Pro+ plan |
+| Log retention | 24 hours | Teams Standard |
+| Device posture checks | Basic only | Teams Standard |
+
+### Testing Constraints
+
+| Constraint | Impact | Mitigation |
+|------------|--------|------------|
+| WARP routing E2E requires enrolled WARP client | Cannot test in CI without WARP setup | Separate test suite or manual validation |
+| GRPCRoute needs gRPC server in test cluster | Test infrastructure expansion | Deploy simple gRPC echo server |
+| UDP testing needs WARP client | Same as WARP routing constraint | Manual validation initially |
+
+## Risk Assessment
+
+| Risk | Severity | Likelihood | Mitigation |
+|------|----------|------------|------------|
+| WARP routing requires client enrollment | Medium | Certain | Document; this is by design |
+| gRPC trailer issues on QUIC | Medium | Known | Auto-detect and warn; recommend HTTP/2 transport |
+| One-TCPRoute-per-listener enforcement | Low | Low | Validate in reconciler; status condition rejection |
+| Virtual network lifecycle complexity | Low | Low | Deferred to v0.3.0 CRD |
+| Enterprise features mixed with free tier | Medium | Medium | Clear documentation; runtime detection where possible |
+| CIDR overlap rejection by API | Medium | Medium | Pre-validate in reconciler; surface as status condition |
+
+## Milestones
+
+| Milestone | Phase | Definition of Done |
+|-----------|-------|-------------------|
+| M1: Foundation | 1 | Client methods implemented, scheme registered, Gateway SupportedKinds dynamic |
+| M2: GRPCRoute | 2 | GRPCRoute controller operational, ingress rules generated with h2c origin |
+| M3: TCPRoute | 3 | TCPRoute controller operational, WARP routing toggles, CIDR routes created |
+| M4: UDPRoute | 4 | UDPRoute controller operational |
+| M5: Testing | 5 | E2E tests passing, CRD validation, documentation complete |
+| M6: Release | N/A | v0.2.0 tagged, chart updated, release notes published |
+
+## Sources
+
+### Cloudflare Documentation
+- [Connect a private network (CIDR)](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/connect-cidr/)
+- [WARP architecture](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/warp-architecture/)
+- [Virtual networks](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/private-net/cloudflared/tunnel-virtual-networks/)
+- [gRPC connections](https://developers.cloudflare.com/network/grpc-connections/)
+- [Tunnel configuration API](https://developers.cloudflare.com/api/resources/zero_trust/subresources/tunnels/subresources/cloudflared/)
+
+### Cloudflare API
+- [Create tunnel route](https://developers.cloudflare.com/api/resources/zero_trust/subresources/networks/subresources/routes/methods/create/)
+- [List tunnel routes](https://developers.cloudflare.com/api/resources/zero_trust/subresources/networks/subresources/routes/methods/list/)
+- [Create virtual network](https://developers.cloudflare.com/api/resources/zero_trust/subresources/networks/subresources/virtual_networks/methods/create/)
+
+### Cloudflare Blog
+- [Getting Cloudflare Tunnels to connect with QUIC](https://blog.cloudflare.com/getting-cloudflare-tunnels-to-connect-to-the-cloudflare-network-with-quic/)
+- [Road to gRPC](https://blog.cloudflare.com/road-to-grpc/)
+- [Build your own private network on Cloudflare](https://blog.cloudflare.com/build-your-own-private-network-on-cloudflare/)
+
+### cloudflared Source (inherent-design fork)
+- `connection/quic_connection.go:287-293`: QUIC transport trailer no-op
+- `connection/http2.go:229-236`: HTTP/2 trailer support
+- `tunnelrpc/proto/tunnelrpc.capnp`: Tunnel RPC schema (capnp)
+- `config/configuration.go:265-269`: WarpRoutingConfig struct
+- `quic/v3/datagram.go`: Datagram v3 binary protocol
+
+### Gateway API
+- [TCPRoute spec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.TCPRoute)
+- [UDPRoute spec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1alpha2.UDPRoute)
+- [GRPCRoute spec](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GRPCRoute)


### PR DESCRIPTION
## Summary

Planning artifacts for cfgate v0.2.0-alpha.1:

- **`docs/planning/v0.2.0-roadmap.md`**: Scope, architecture decisions (4 ADRs), controller topology diagrams, 5 implementation phases, file change manifest, CRD design, risk assessment, milestones
- **`docs/planning/v0.2.0-protocol-analysis.md`**: cloudflared transport architecture (quic-go + capnp), HTTP/2 vs HTTP/3 trailer semantics, WARP/WireGuard architecture, TCP/UDP proxying models, SDK coverage assessment, free tier feature map

### Key Decisions

1. **WARP routing over Spectrum** for L4: free tier, handles TCP and UDP
2. **Extend CloudflareTunnel CRD** (not new CRD) for v0.2.0; defer CloudflarePrivateNetwork to v0.3.0
3. **GRPCRoute requires HTTP/2 transport**: QUIC drops trailers silently
4. **TCPRoute dual-path**: public hostname ingress OR private WARP routing

### Implementation Phases

- Phase 1: Foundation (client expansion, scheme registration, gateway SupportedKinds)
- Phase 2: GRPCRoute (lowest risk; same ingress-rule pattern as HTTPRoute)
- Phase 3: TCPRoute + WARP routing (CIDR route management)
- Phase 4: UDPRoute (same pattern as private TCPRoute)
- Phase 5: Integration testing and documentation

### Scope

- 3 new controllers (GRPCRoute, TCPRoute, UDPRoute)
- 10 new Client interface methods (5 route + 5 vnet)
- 15 files affected (10 modified, 3 new, 2 auto-generated)
- All features free tier compatible (50-user WARP limit is primary constraint)

## Test plan

- [ ] Review roadmap architecture decisions for completeness
- [ ] Cross-reference protocol analysis against cloudflared source