### PR TITLE
fix: standardize manager CLI exit codes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,8 @@ mise run smoke             # fast local sanity check
 
 E2E is local-only. Normal GitHub Actions CI runs lint, unit tests, build validation, and unit coverage. It does not provision a cluster or run Cloudflare-backed E2E.
 
+`mise run smoke` builds `bin/manager`, requires `./bin/manager --help` to exit successfully, then runs the fast package test set. `cmd/cleanup` is not part of the smoke or release CLI contract in this pass.
+
 Two local bootstrap paths are first-class:
 
 ```bash

--- a/cmd/manager/doc.go
+++ b/cmd/manager/doc.go
@@ -42,6 +42,14 @@
 //	mise run build
 //	./bin/manager
 //
+// # Exit Codes
+//
+// The manager uses a small POSIX-style exit code contract:
+//
+//	0    Successful execution, including explicit -h/--help requests
+//	2    Invalid flags or invalid CFGATE_* configuration
+//	1    Runtime failures after configuration parsing succeeds
+//
 // Deploy to cluster:
 //
 //	mise run local:deploy

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -34,6 +35,9 @@ const (
 	defaultHealthPort  = 8081
 	envMetricsPort     = "CFGATE_METRICS_PORT"
 	envHealthPort      = "CFGATE_HEALTH_PORT"
+	exitCodeSuccess    = 0
+	exitCodeRuntime    = 1
+	exitCodeUsage      = 2
 )
 
 var (
@@ -64,6 +68,23 @@ type managerRuntime struct {
 	startManager        func(manager.Manager) error
 }
 
+type cliExitError struct {
+	code    int
+	err     error
+	printed bool
+}
+
+func (e cliExitError) Error() string {
+	if e.err == nil {
+		return ""
+	}
+	return e.err.Error()
+}
+
+func (e cliExitError) Unwrap() error {
+	return e.err
+}
+
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(cfgatev1alpha1.AddToScheme(scheme))
@@ -72,10 +93,7 @@ func init() {
 }
 
 func main() {
-	if err := run(os.Args[1:], os.Getenv, os.Stderr, defaultManagerRuntime()); err != nil {
-		setupLog.Error(err, "unable to run manager")
-		os.Exit(1)
-	}
+	os.Exit(execute(os.Args[1:], os.Getenv, os.Stderr, defaultManagerRuntime()))
 }
 
 func defaultManagerRuntime() managerRuntime {
@@ -159,15 +177,36 @@ func run(args []string, getenv func(string) string, stderr io.Writer, runtime ma
 	return nil
 }
 
+func execute(args []string, getenv func(string) string, stderr io.Writer, runtime managerRuntime) int {
+	err := run(args, getenv, stderr, runtime)
+	if err == nil {
+		return exitCodeSuccess
+	}
+
+	var cliErr cliExitError
+	if errors.As(err, &cliErr) {
+		if cliErr.code == exitCodeSuccess {
+			return exitCodeSuccess
+		}
+		if cliErr.err != nil && !cliErr.printed {
+			_, _ = fmt.Fprintln(stderr, cliErr.err)
+		}
+		return cliErr.code
+	}
+
+	setupLog.Error(err, "unable to run manager")
+	return exitCodeRuntime
+}
+
 func parseManagerConfig(args []string, getenv func(string) string, stderr io.Writer) (managerConfig, error) {
 	metricsPort, err := parsePortEnv(getenv, envMetricsPort, defaultMetricsPort)
 	if err != nil {
-		return managerConfig{}, err
+		return managerConfig{}, cliExitError{code: exitCodeUsage, err: err}
 	}
 
 	probePort, err := parsePortEnv(getenv, envHealthPort, defaultHealthPort)
 	if err != nil {
-		return managerConfig{}, err
+		return managerConfig{}, cliExitError{code: exitCodeUsage, err: err}
 	}
 
 	cfg := managerConfig{
@@ -191,7 +230,10 @@ func parseManagerConfig(args []string, getenv func(string) string, stderr io.Wri
 	cfg.ZapOptions.BindFlags(fs)
 
 	if err := fs.Parse(args); err != nil {
-		return managerConfig{}, err
+		if errors.Is(err, flag.ErrHelp) {
+			return managerConfig{}, cliExitError{code: exitCodeSuccess, err: err, printed: true}
+		}
+		return managerConfig{}, cliExitError{code: exitCodeUsage, err: err, printed: true}
 	}
 
 	return cfg, nil

--- a/cmd/manager/main_test.go
+++ b/cmd/manager/main_test.go
@@ -136,7 +136,7 @@ func TestBuildManagerOptions(t *testing.T) {
 	}
 }
 
-func TestRunManager(t *testing.T) {
+func TestExecuteManager(t *testing.T) {
 	t.Run("success path", func(t *testing.T) {
 		var calls []string
 		gotMetrics := ""
@@ -167,8 +167,8 @@ func TestRunManager(t *testing.T) {
 			},
 		}
 
-		if err := run(nil, func(string) string { return "" }, io.Discard, runtime); err != nil {
-			t.Fatalf("run() error = %v", err)
+		if code := execute(nil, func(string) string { return "" }, io.Discard, runtime); code != exitCodeSuccess {
+			t.Fatalf("execute() = %d, want %d", code, exitCodeSuccess)
 		}
 
 		wantCalls := []string{
@@ -187,14 +187,32 @@ func TestRunManager(t *testing.T) {
 		}
 	})
 
-	t.Run("returns parse errors", func(t *testing.T) {
-		err := run(nil, func(string) string { return "bad" }, io.Discard, managerRuntime{})
-		if err == nil || !strings.Contains(err.Error(), envMetricsPort) {
-			t.Fatalf("run() error = %v, want %q in error", err, envMetricsPort)
+	t.Run("help exits zero", func(t *testing.T) {
+		for _, arg := range []string{"--help", "-h"} {
+			t.Run(arg, func(t *testing.T) {
+				stderr := &bytes.Buffer{}
+				if code := execute([]string{arg}, func(string) string { return "" }, stderr, managerRuntime{}); code != exitCodeSuccess {
+					t.Fatalf("execute() = %d, want %d", code, exitCodeSuccess)
+				}
+				if stderr.Len() == 0 {
+					t.Fatal("stderr was empty, want help output")
+				}
+			})
 		}
 	})
 
-	t.Run("returns runtime errors", func(t *testing.T) {
+	t.Run("bad env returns usage exit code", func(t *testing.T) {
+		stderr := &bytes.Buffer{}
+		code := execute(nil, func(string) string { return "bad" }, stderr, managerRuntime{})
+		if code != exitCodeUsage {
+			t.Fatalf("execute() = %d, want %d", code, exitCodeUsage)
+		}
+		if !strings.Contains(stderr.String(), envMetricsPort) {
+			t.Fatalf("stderr = %q, want %q in error", stderr.String(), envMetricsPort)
+		}
+	})
+
+	t.Run("runtime errors return runtime exit code", func(t *testing.T) {
 		runtime := managerRuntime{
 			setLogger: func(logr.Logger) {},
 			createManager: func(managerConfig) (manager.Manager, *rest.Config, error) {
@@ -205,20 +223,22 @@ func TestRunManager(t *testing.T) {
 			},
 		}
 
-		err := run(nil, func(string) string { return "" }, io.Discard, runtime)
-		if err == nil || !strings.Contains(err.Error(), "detect failed") {
-			t.Fatalf("run() error = %v, want detect failure", err)
+		if code := execute(nil, func(string) string { return "" }, io.Discard, runtime); code != exitCodeRuntime {
+			t.Fatalf("execute() = %d, want %d", code, exitCodeRuntime)
 		}
 	})
 
-	t.Run("passes flagset errors through", func(t *testing.T) {
+	t.Run("unknown flags return usage exit code", func(t *testing.T) {
 		stderr := &bytes.Buffer{}
-		err := run([]string{"--unknown-flag"}, func(string) string { return "" }, stderr, managerRuntime{})
-		if err == nil {
-			t.Fatal("run() error = nil, want flag parsing error")
+		if code := execute([]string{"--unknown-flag"}, func(string) string { return "" }, stderr, managerRuntime{}); code != exitCodeUsage {
+			t.Fatalf("execute() = %d, want %d", code, exitCodeUsage)
 		}
-		if stderr.Len() == 0 {
+		output := stderr.String()
+		if output == "" {
 			t.Fatal("stderr was empty, want flag usage output")
+		}
+		if !strings.Contains(output, "flag provided but not defined") {
+			t.Fatalf("stderr = %q, want unknown flag error", output)
 		}
 	})
 }

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -336,4 +336,4 @@ mise run smoke
 - `profile:bench` writes CPU and heap profiles under `out/profiles/`
 - `profile:view` launches the pprof web UI
 - `profile:export` writes `top`, `tree`, and `proto` outputs beside the selected profile
-- `smoke` runs a fast local build-plus-test sanity pass
+- `smoke` builds `bin/manager`, verifies `./bin/manager --help` exits successfully, then runs a fast local package test pass

--- a/mise.toml
+++ b/mise.toml
@@ -312,14 +312,7 @@ description = "Run a fast local smoke suite"
 run = """
 set -eu
 mise run build
-if ./bin/manager --help >/dev/null 2>&1; then
-  :
-else
-  status=$?
-  if [ "$status" -ne 1 ] && [ "$status" -ne 2 ]; then
-    exit "$status"
-  fi
-fi
+./bin/manager --help >/dev/null 2>&1
 go test -count=1 ./api/... ./cmd/... ./internal/...
 """
 


### PR DESCRIPTION
## Summary
- treat explicit manager help as successful control flow with exit code 0
- classify invalid flags and invalid CFGATE_* configuration as usage errors with exit code 2
- align the local smoke task and docs with the stricter release smoke contract

## Test plan
- go test ./cmd/manager
- mise run lint
- mise run build
- ./bin/manager --help
- mise run smoke
- IMG=cfgate:smoke-test mise run docker:build
- docker run --rm cfgate:smoke-test --help
