### PR TITLE
release: prepare changelog and e2e automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,47 @@ env:
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
+  e2e:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    env:
+      MISE_SOPS_AGE_KEY: ${{ secrets.MISE_SOPS_AGE_KEY }}
+      MISE_SOPS_ROPS: "true"
+      E2E_USE_EXISTING_CLUSTER: "false"
+      E2E_PROCS: "2"
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: jdx/mise-action@v4
+
+      - name: Validate release E2E secrets
+        run: mise run e2e:preflight
+
+      - name: Run release E2E
+        run: mise run e2e
+
+      - name: Upload E2E artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-e2e-${{ github.ref_name }}
+          path: |
+            out/reports/e2e.json
+            out/coverage/e2e.coverprofile
+          if-no-files-found: warn
+
+      - name: Upload E2E coverage to Codecov
+        if: always() && hashFiles('out/coverage/e2e.coverprofile') != ''
+        uses: codecov/codecov-action@v6
+        with:
+          files: out/coverage/e2e.coverprofile
+          flags: e2e,release
+          fail_ci_if_error: false
+
   release:
+    needs: e2e
     runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     permissions:
@@ -165,7 +205,7 @@ jobs:
         run: |
           IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.clean }} mise run manifests
 
-      - name: Generate changelog
+      - name: Generate release notes
         id: changelog
         uses: orhun/git-cliff-action@v4
         with:
@@ -174,9 +214,26 @@ jobs:
         env:
           GITHUB_REPO: ${{ github.repository }}
 
+      - name: Generate full changelog
+        uses: orhun/git-cliff-action@v4
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md
+        env:
+          GITHUB_REPO: ${{ github.repository }}
+
+      - name: Commit changelog to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout main
+          git add CHANGELOG.md
+          git diff --cached --quiet || git commit -m "chore: update changelog for ${{ steps.version.outputs.clean }}"
+          git push origin main
+
       - uses: softprops/action-gh-release@v2
         with:
-          body: ${{ steps.changelog.outputs.content }}
+          body_path: ${{ steps.changelog.outputs.changelog }}
           prerelease: ${{ steps.channel.outputs.prerelease == 'true' }}
           files: |
             dist/install.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,14 +103,16 @@ jobs:
           else
             HAS_STABLE=false
             HAS_BETA=false
+            HAS_RC=false
             for tag in $(git tag -l 'v*' | grep -v "^${GITHUB_REF_NAME}$"); do
               v="${tag#v}"
               [[ "$v" != *"-"* ]] && HAS_STABLE=true
-              [[ "$v" == *"-beta."* || "$v" == *"-rc."* ]] && HAS_BETA=true
+              [[ "$v" == *"-beta."* ]] && HAS_BETA=true
+              [[ "$v" == *"-rc."* ]] && HAS_RC=true
             done
-            if [[ "$VERSION" == *"-alpha."* && "$HAS_BETA" == "false" && "$HAS_STABLE" == "false" ]]; then
+            if [[ "$VERSION" == *"-alpha."* && "$HAS_BETA" == "false" && "$HAS_RC" == "false" && "$HAS_STABLE" == "false" ]]; then
               IS_LATEST=true
-            elif [[ "$VERSION" == *"-beta."* && "$HAS_STABLE" == "false" ]]; then
+            elif [[ "$VERSION" == *"-beta."* && "$HAS_STABLE" == "false" && "$HAS_RC" == "false" ]]; then
               IS_LATEST=true
             elif [[ "$VERSION" == *"-rc."* && "$HAS_STABLE" == "false" ]]; then
               IS_LATEST=true
@@ -214,26 +216,9 @@ jobs:
         env:
           GITHUB_REPO: ${{ github.repository }}
 
-      - name: Generate full changelog
-        uses: orhun/git-cliff-action@v4
-        with:
-          config: cliff.toml
-          args: --output CHANGELOG.md
-        env:
-          GITHUB_REPO: ${{ github.repository }}
-
-      - name: Commit changelog to main
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout main
-          git add CHANGELOG.md
-          git diff --cached --quiet || git commit -m "chore: update changelog for ${{ steps.version.outputs.clean }}"
-          git push origin main
-
       - uses: softprops/action-gh-release@v2
         with:
-          body_path: ${{ steps.changelog.outputs.changelog }}
+          body: ${{ steps.changelog.outputs.content }}
           prerelease: ${{ steps.channel.outputs.prerelease == 'true' }}
           files: |
             dist/install.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
           files: out/coverage/e2e.coverprofile
           flags: e2e,release
           fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   release:
     needs: e2e

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ For contributor PRs, the maintainer squash-merges with a clean conventional subj
 
 ## Changelog
 
-Release notes are generated via [git-cliff](https://git-cliff.org/) from commit history. Configuration is in `cliff.toml`. Do not edit CHANGELOG.md manually. Tagged releases regenerate `CHANGELOG.md` and commit the updated file back to `main` from the release workflow.
+Release notes are generated via [git-cliff](https://git-cliff.org/) from commit history. Configuration is in `cliff.toml`. Do not edit `CHANGELOG.md` manually; regenerate it locally with `git-cliff` when you need to refresh the repo changelog.
 
 ## Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ For contributor PRs, the maintainer squash-merges with a clean conventional subj
 
 ## Changelog
 
-Release notes are generated via [git-cliff](https://git-cliff.org/) from commit history. Configuration is in `cliff.toml`. Do not edit CHANGELOG.md manually.
+Release notes are generated via [git-cliff](https://git-cliff.org/) from commit history. Configuration is in `cliff.toml`. Do not edit CHANGELOG.md manually. Tagged releases regenerate `CHANGELOG.md` and commit the updated file back to `main` from the release workflow.
 
 ## Code Style
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -9,9 +9,9 @@ All notable changes to cfgate are documented in this file.\n
 """
 body = """
 {%- if version %}
-## {{ version }} - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- else %}
-## Unreleased
+## [Unreleased]
 {%- endif %}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim | upper_first }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -9,9 +9,9 @@ All notable changes to cfgate are documented in this file.\n
 """
 body = """
 {%- if version %}
-## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+## {{ version }} - {{ timestamp | date(format="%Y-%m-%d") }}
 {%- else %}
-## [Unreleased]
+## Unreleased
 {%- endif %}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim | upper_first }}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -110,7 +110,7 @@ This runs the full local suite with:
 - Coverage instrumentation for `./api/...`, `./cmd/...`, and `./internal/...`
 - Progress polling after 15s silence
 
-E2E is intentionally local-only. The normal GitHub Actions CI workflows do not provision a cluster, do not use Cloudflare secrets, and do not upload E2E coverage to Codecov.
+E2E remains excluded from normal PR and push CI because of cost and Cloudflare rate-limit pressure. Tag-triggered releases are the only GitHub Actions workflow that provisions kind, decrypts release secrets, runs the Cloudflare-backed E2E suite, and uploads E2E coverage to Codecov.
 
 #### Run Specific Tests
 

--- a/mise.toml
+++ b/mise.toml
@@ -248,6 +248,22 @@ set -eu
 E2E_FOCUS="{{arg(name='filter')}}" mise run e2e
 """
 
+[tasks."e2e:preflight"]
+hide = true
+description = "Validate release E2E secrets"
+env = { _.file = ["secrets.enc.yaml", ".env"] }
+run = """
+set -eu
+required_vars="CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_ZONE_NAME CLOUDFLARE_IDP_ID CLOUDFLARE_TEST_EMAIL CLOUDFLARE_TEST_GROUP"
+for var in $required_vars; do
+  if [ -z "${!var:-}" ]; then
+    echo "${var} is required for release E2E" >&2
+    exit 1
+  fi
+done
+echo "Release E2E secret preflight passed"
+"""
+
 [tasks."e2e:cleanup"]
 alias = ["clean"]
 description = "Clean up orphaned E2E test resources from Cloudflare"

--- a/mise.toml
+++ b/mise.toml
@@ -253,6 +253,7 @@ hide = true
 description = "Validate release E2E secrets"
 env = { _.file = ["secrets.enc.yaml", ".env"] }
 run = """
+#!/usr/bin/env bash
 set -eu
 required_vars="CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_ZONE_NAME CLOUDFLARE_IDP_ID CLOUDFLARE_TEST_EMAIL CLOUDFLARE_TEST_GROUP"
 for var in $required_vars; do


### PR DESCRIPTION
## Summary
- add release-only blocking E2E with secret preflight, artifacts, and Codecov upload
- mirror empack's git-cliff flow by generating release notes plus full CHANGELOG.md and committing changelog updates back to main during tagged releases
- document the future release-time changelog and E2E behavior

## Test plan
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml")'
- git-cliff --config cliff.toml --unreleased --strip header
- MISE_SOPS_AGE_KEY="$(grep '^AGE-SECRET-KEY-' ~/.config/sops/age/keys.txt)" MISE_SOPS_ROPS=true mise run e2e:preflight
