### PR TITLE
docs: refresh current surface references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,172 @@
 All notable changes to cfgate are documented in this file.
 
 
+## [Unreleased]
+
+### Bug Fixes
+
+- **(release)** Drop changelog writeback and tighten latest tags
+- **(release)** Harden e2e preflight and coverage upload
+- Correct assurance score metadata and review notes
+- Harden coverage helper scripts
+- Honor coverage mode in profile merge
+- Fail coverage merge pipelines on awk errors
+
+### Testing
+
+- Add merged coverage tooling and orchestration tests
+- Expand e2e coverage and drop access mtls
+- Drop unused e2e helper stubs
+
+### Refactoring
+
+- Remove retired route surface from current product
+
+### CI/CD
+
+- Add manual remote E2E workflow
+
+### Other
+
+- Prepare changelog and e2e automation
+- Sync dev with main before coverage work
+- Merge pull request #55 from cfgate/dev
+
+test: add merged coverage tooling and orchestration tests
+
+## [0.1.0-alpha.20] - 2026-04-10
+
+### Bug Fixes
+
+- Correct Artifact Hub shield URL
+- **(manager)** Standardize CLI exit codes
+
+### Testing
+
+- Adopt h2c.2 and harden e2e cleanup
+- Adopt h2c.2 and harden e2e cleanup
+
+### Infrastructure
+
+- Scope mise secrets to e2e tasks
+- Update golangci-lint for Go 1.26
+- Use Go 1.26 in Docker image
+- Scope mise runtime defaults to tasks
+- Scope mise secrets to e2e tasks
+- Update golangci-lint for Go 1.26
+- Use Go 1.26 in Docker image
+- Scope mise runtime defaults to tasks
+
+### CI/CD
+
+- Add Renovate for dependency automation
+- Migrate release workflow to Node 24 actions
+- Gate dev coverage on lint
+- Run pull request validation on dev
+- Skip mise env loading in automation
+- Gate dev coverage on lint
+- Run pull request validation on dev
+- Skip mise env loading in automation
+
+### Maintenance
+
+- Bump cloudflared fork to v2026.3.0-h2c.1 and document fork dependency
+- Migrate cfgate automation to mise
+- Migrate cfgate automation to mise
+
+## [0.1.0-alpha.19] - 2026-03-15
+
+### Features
+
+- **(dns)** Support A/AAAA record types and subdomain depth warnings
+- **(dns)** Implement NamespaceSelector for route filtering
+
+### Bug Fixes
+
+- **(access)** Order-insensitive comparison for drift detection
+- **(client)** Replace string-based error detection with SDK type assertions
+- **(dns)** Cross-reference TXT ownership during cleanup to prevent cross-resource deletion
+- **(cloudflare)** Include email addresses in approvalGroupsEqual sort key
+- Correct buildRulesFromHTTPRoute, convertAccessRules, and CEL test helper
+- Block finalizer removal on cleanup failure with retry budgets
+- Address PR #47 review findings
+- **(e2e)** Reverse CR deletion order to respect credential dependencies
+
+### Testing
+
+- **(client)** Add MockClient for unit and integration testing
+- Add P0 unit tests for status conditions, DNS diff, and access drift
+- Add P2 unit tests for cache, predicates, features, and builders (#34, #35)
+
+### Documentation
+
+- Rewrite CONTRIBUTING.md to prose reference conventions
+- Update TESTING.md for two-tier test strategy
+- Add deletion behavior, record types, subdomain warnings, and DNS orphan E2E
+
+### Refactoring
+
+- **(client)** Compose Client interface from 9 domain interfaces (#26)
+- **(client)** Unify param types and extract SDK conversions (#27, #28)
+
+### CI/CD
+
+- Bump trivy-action to 0.35.0
+- Bump trivy-action to 0.35.0
+
+### Maintenance
+
+- Add unit test tasks and fix CONTRIBUTING.md task table
+- Fix lint and format issues
+- Remove unused ZoneName field from DNSRecord
+
+## [0.1.0-alpha.18] - 2026-02-24
+
+### Bug Fixes
+
+- Translate h2cOrigin to CF API tunnel configuration
+- Add runtime mutual exclusivity guard for h2cOrigin/http2Origin
+
+### Testing
+
+- Add E2E tests for h2cOrigin annotation and CEL validation
+
+### Maintenance
+
+- Bump default cloudflared image to 2026.2.0-h2c.2
+
+### Other
+
+- Merge pull request #3 from cfgate/dev
+
+fix: translate h2cOrigin to CF API tunnel configuration
+
+## [0.1.0-alpha.17] - 2026-02-24
+
+### Bug Fixes
+
+- Remove v prefix from default cloudflared image tag
+
+## [0.1.0-alpha.16] - 2026-02-24
+
+### Features
+
+- Default cloudflared image to inherent-design fork
+
+## [0.1.0-alpha.15] - 2026-02-24
+
+### Features
+
+- Add h2cOrigin support and fix liveness probe
+
+### Bug Fixes
+
+- Enforce h2cOrigin/http2Origin mutual exclusivity
+
+### CI/CD
+
+- **(release)** Stop marking GitHub releases as pre-release
+
 ## [0.1.0-alpha.13] - 2026-02-21
 
 ### Bug Fixes
@@ -22,6 +188,7 @@ All notable changes to cfgate are documented in this file.
 - Generate changelog
 - Bind container image
 - Add CI workflows, ignore E2E output directory
+- Generate changelog for v0.1.0-alpha.13
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ cfgate automatically:
 
 **CloudflareDNS** syncs DNS records independently from tunnel lifecycle, with multi-zone support and ownership tracking. → [Full reference](docs/cloudflare-dns.md)
 
-**CloudflareAccessPolicy** manages Cloudflare Access applications and policies for zero-trust authentication against Gateway API targets. → [Full reference](docs/cloudflare-access-policy.md)
+**CloudflareAccessPolicy** manages Cloudflare Access applications and policies for zero-trust authentication against `Gateway` and `HTTPRoute` targets. → [Full reference](docs/cloudflare-access-policy.md)
 
 Per-route configuration (origin protocol, TLS settings, timeouts, DNS TTL) is set via annotations on Gateway API HTTPRoute resources. → [Full reference](docs/annotations.md)
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -173,12 +173,13 @@ Run cleanup before E2E tests to ensure a clean slate if previous runs left orpha
 test/e2e/
   e2e_suite_test.go     # Suite setup, framework init, cleanup helpers
   helpers_test.go       # Wait functions, resource creators, CF API verifiers
-  tunnel_test.go        # CloudflareTunnel lifecycle (17 specs)
-  dns_test.go           # CloudflareDNS sync, policies, ownership (19 specs)
-  access_test.go        # CloudflareAccessPolicy rules and applications (26 specs)
+  tunnel_test.go        # CloudflareTunnel lifecycle and recovery paths (~20 specs)
+  dns_test.go           # CloudflareDNS sync, cleanup, ownership, and fallback paths (~27 specs)
+  access_test.go        # CloudflareAccessPolicy targets, rules, and service tokens (~29 specs)
   annotations_test.go   # HTTPRoute annotation parsing and propagation (16 specs)
   combined_test.go      # Multi-CRD interaction and cross-resource tests (7 specs)
-  invariants_test.go    # Structural invariants across all CRDs (10 specs, 45 assertions)
+  gateway_route_status_test.go # Gateway / HTTPRoute negative and status coverage (7 specs)
+  invariants_test.go    # Structural invariants across tunnel, DNS, Access, Gateway, and HTTPRoute (10 specs)
   validation_test.go    # CEL validation rules, no Cloudflare API needed (12 specs)
 ```
 
@@ -249,14 +250,19 @@ Never use bare `Get` followed by `Expect(Update).To(Succeed())`; the controller 
 | `waitForTunnelReady` | Tunnel status Ready=True |
 | `waitForTunnelCondition` | Specific condition on tunnel |
 | `waitForTunnelDeleted` | Tunnel removed from K8s |
-| `waitForTunnelDeletedFromCloudflare` | Tunnel removed from Cloudflare API |
+| `waitForTunnelDeletedByIDFromCloudflare` | Tunnel removed from Cloudflare API by tunnel ID |
 | `waitForDeploymentSpec` | cloudflared Deployment matches expected replicas |
 | `waitForDNSReady` | DNS status Ready=True (defined in dns_test.go) |
 | `waitForDNSDeleted` | DNS resource removed from K8s (defined in dns_test.go) |
 | `waitForAccessPolicyReady` | Access policy status Ready=True |
+| `waitForAccessPolicyCondition` | Specific condition on Access policy |
 | `waitForAccessPolicyDeleted` | Access policy removed from K8s |
+| `waitForGatewayCondition` | Specific condition on Gateway |
+| `waitForHTTPRouteParentCondition` | Specific parent condition on HTTPRoute |
 | `waitForAccessApplicationDeletedFromCloudflare` | Access app removed from Cloudflare API |
+| `waitForServiceTokenDeletedFromCloudflare` | Service token removed from Cloudflare API |
 | `waitForServiceTokenSecretCreated` | Service token Secret created in K8s |
+| `waitForEventReason` | Matching Kubernetes event emitted |
 
 #### Resource Creators
 
@@ -268,22 +274,25 @@ Never use bare `Get` followed by `Expect(Update).To(Succeed())`; the controller 
 | `createCloudflareDNSWithGatewayRoutes` | CloudflareDNS with gateway route discovery |
 | `createCloudflareAccessPolicy` | Basic Access policy |
 | `createCloudflareAccessPolicyWith*` | Access policy with specific rule type (IP, country, email, OIDC, GSuite) |
+| `createGatewayClassWithController` | GatewayClass with explicit controllerName |
 | `createGatewayClass` | GatewayClass for cfgate |
 | `createGateway` | Gateway with tunnel reference |
 | `createHTTPRoute` | HTTPRoute with hostname and backend |
 | `createTestService` | ClusterIP Service for backends |
+| `createCloudflareCredentialsSecret` | Secret with Cloudflare API token for test namespaces |
 
 #### Invariant Tests
 
 Invariant tests (`invariants_test.go`) verify structural properties that MUST hold whenever a resource reaches a known state. Unlike scenario tests ("do X, expect Y"), invariant tests verify "whenever state S holds, properties P1..Pn MUST hold" regardless of how the resource reached that state.
 
-Eight test contexts cover 45 assertions:
+The current invariant suite covers these resource families:
 
 | Context | IDs | What it verifies |
 |---------|-----|-----------------|
 | CloudflareTunnel Ready | INV-T1..T9 | Sub-conditions, TunnelID, TunnelDomain format, finalizer, deployment, config-hash |
 | CloudflareDNS Ready | INV-D1..D8 | Sub-conditions, SyncedRecords, ResolvedTarget, CF API CNAME, OwnershipVerified |
 | CloudflareAccessPolicy Ready | INV-A1..A8 | Sub-conditions, ApplicationID, targets, finalizer, CF API app |
+| Service token invariants | INV-ST1..ST4 | Service token Secret shape, status IDs, Cloudflare token presence |
 | Gateway status | INV-GW1..GW4 | Accepted, Programmed, addresses, supportedKinds |
 | HTTPRoute parent status | INV-HR1..HR3 | parents[] controllerName, Accepted, ResolvedRefs |
 | GatewayClass | INV-GC1..GC2 | controllerName match, Accepted |

--- a/docs/cloudflare-dns.md
+++ b/docs/cloudflare-dns.md
@@ -42,8 +42,8 @@ When using `tunnelRef`, credentials are inherited from the referenced [Cloudflar
 | `spec.ownership.ownerId` | `string` | *(namespace/name of the CloudflareDNS resource)* | No | Cluster/installation identifier for TXT ownership records. Max 253 chars. Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?(/[a-z0-9]([-a-z0-9]*[a-z0-9])?)?$`. |
 | `spec.ownership.txtRecord.enabled` | `*bool` | `true` (nil defaults to true) | No | Enables TXT record-based ownership tracking. |
 | `spec.ownership.txtRecord.prefix` | `string` | `_cfgate` | No | Prefix for TXT record names. Max 63 chars. |
-| `spec.ownership.comment.enabled` | `bool` | `false` | No | **Deprecated (alpha.13).** Ignored; the controller always writes a fixed comment. Will be removed in alpha.14. |
-| `spec.ownership.comment.template` | `string` | `managed by cfgate` | No | **Deprecated (alpha.13).** Ignored; the controller always uses `"managed by cfgate"`. Will be removed in alpha.14. |
+| `spec.ownership.comment.enabled` | `bool` | `false` | No | **Deprecated (alpha.13).** Ignored; the controller always writes a fixed comment. Schema removal is deferred to a future cleanup. |
+| `spec.ownership.comment.template` | `string` | `managed by cfgate` | No | **Deprecated (alpha.13).** Ignored; the controller always uses `"managed by cfgate"`. Schema removal is deferred to a future cleanup. |
 | `spec.cleanupPolicy.deleteOnRouteRemoval` | `*bool` | `true` (nil defaults to true) | No | Delete DNS records when the source route is deleted. |
 | `spec.cleanupPolicy.deleteOnResourceRemoval` | `*bool` | `true` (nil defaults to true) | No | Delete DNS records when the CloudflareDNS resource itself is deleted (finalizer cleanup). |
 | `spec.cleanupPolicy.onlyManaged` | `*bool` | `true` (nil defaults to true) | No | Only delete records that were created by cfgate, verified via ownership tracking. |
@@ -191,9 +191,9 @@ heritage=cfgate,cfgate/owner=<owner-id>,cfgate/resource=cloudflaredns/<namespace
 ```
 This pattern is compatible with external-dns. The TXT record name is `{prefix}.{hostname}` (e.g., `_cfgate.app.example.com`).
 
-**Comment ownership (cosmetic only):** The controller writes a fixed `"managed by cfgate"` comment on all managed DNS records. This is informational only and is not used for ownership verification or conflict detection. TXT record ownership is the sole mechanism for multi-cluster safety.
+**Comment ownership (compatibility only):** The controller writes a fixed `"managed by cfgate"` comment on all managed DNS records. This is informational only and is not used for ownership verification or conflict detection. TXT record ownership is the sole mechanism for multi-cluster safety.
 
-> **Deprecation notice (alpha.13):** The `spec.ownership.comment.enabled` and `spec.ownership.comment.template` fields are deprecated and ignored. The controller always writes `"managed by cfgate"` regardless of these values. Both fields will be removed in **v0.1.0-alpha.14**. To migrate, remove the `comment` section from `spec.ownership` in your CloudflareDNS resources. No behavioral change occurs; the hardcoded value matches the previous defaults.
+> **Deprecation notice (alpha.13):** The `spec.ownership.comment.enabled` and `spec.ownership.comment.template` fields are deprecated and ignored. The controller always writes `"managed by cfgate"` regardless of these values. The fields remain in the schema for compatibility, and schema removal is deferred to a future cleanup pass. Removing the `comment` section from `spec.ownership` produces no behavioral change.
 
 **`ownerId`:** Identifies this installation. Defaults to `{namespace}/{name}` of the CloudflareDNS resource. Override this when you need explicit control over the identity (e.g., migrating between CloudflareDNS resources).
 
@@ -394,7 +394,7 @@ The controller adds the finalizer `cfgate.io/dns-cleanup` to every CloudflareDNS
 
 If cleanup fails, the controller blocks indefinitely and requeues every 15 seconds. It never removes the finalizer automatically. Within a 1-minute retry budget, the controller emits Warning events with reason `CleanupFailed`. After the retry budget is exhausted, subsequent events escalate to reason `CleanupBlocked`.
 
-To skip Cloudflare cleanup and remove the finalizer immediately, set the `cfgate.io/deletion-policy=orphan` annotation on the CloudflareDNS resource. The controller will leave DNS records in Cloudflare and remove the finalizer without attempting cleanup. This annotation is new in v0.1.0-alpha.14; previous releases supported it only on CloudflareTunnel and CloudflareAccessPolicy.
+To skip Cloudflare cleanup and remove the finalizer immediately, set the `cfgate.io/deletion-policy=orphan` annotation on the CloudflareDNS resource. The controller will leave DNS records in Cloudflare and remove the finalizer without attempting cleanup.
 
 ```bash
 kubectl annotate cloudflarednses my-dns -n cfgate-system \


### PR DESCRIPTION
## Summary
- refresh tracked docs to match the current Gateway/HTTPRoute-only cfgate surface
- update testing and DNS docs for the current helper inventory, coverage artifacts, and deprecated comment-field behavior
- regenerate the repo changelog from current history

## Test plan
- mise run lint
- go test ./api/... ./cmd/... ./internal/... -run '^$'

## Notes
- helm-chart sync is intentionally deferred until cfgate v0.1.0-alpha.21 exists