### PR TITLE
fix: unblock dns partial-sync cleanup

### DIFF
--- a/internal/controller/cloudflaredns_cleanup_test.go
+++ b/internal/controller/cloudflaredns_cleanup_test.go
@@ -181,6 +181,88 @@ func TestCleanupRecordsWithFallbackUsesStatusInventory(t *testing.T) {
 	}
 }
 
+func TestCleanupRecordsWithFallbackSkipsFailedStatusRecordsWithoutMaterializedRemoteState(t *testing.T) {
+	ctx := context.Background()
+	mock := cloudflare.NewMockClient()
+	deleted := []string{}
+	resolvedUnexpectedZone := false
+
+	mock.ListDNSRecordsByNameTypeFunc = func(_ context.Context, _, name, recordType string) ([]cloudflare.DNSRecord, error) {
+		switch {
+		case name == "good.example.com" && recordType == "CNAME":
+			return []cloudflare.DNSRecord{{
+				ID:      "good-id",
+				Name:    name,
+				Type:    recordType,
+				Content: "target.example.com",
+				Comment: "managed by cfgate",
+			}}, nil
+		case name == "_cfgate.good.example.com" && recordType == "TXT":
+			return nil, nil
+		default:
+			return nil, nil
+		}
+	}
+	mock.GetZoneByNameFunc = func(_ context.Context, name string) (*cloudflare.Zone, error) {
+		if name == "example.invalid" {
+			resolvedUnexpectedZone = true
+		}
+		return nil, nil
+	}
+	mock.DeleteDNSRecordFunc = func(_ context.Context, _, recordID string) error {
+		deleted = append(deleted, recordID)
+		return nil
+	}
+
+	disabledTXT := false
+	dns := &cfgatev1alpha1.CloudflareDNS{
+		Spec: cfgatev1alpha1.CloudflareDNSSpec{
+			Cloudflare: &cfgatev1alpha1.CloudflareConfig{
+				SecretRef: cfgatev1alpha1.SecretRef{Name: "cloudflare-credentials"},
+			},
+			Zones: []cfgatev1alpha1.DNSZoneConfig{{
+				Name: "example.com",
+				ID:   "zone-1",
+			}},
+			Ownership: cfgatev1alpha1.DNSOwnershipConfig{
+				TXTRecord: cfgatev1alpha1.DNSTXTRecordOwnership{
+					Enabled: &disabledTXT,
+					Prefix:  "_cfgate",
+				},
+			},
+		},
+		Status: cfgatev1alpha1.CloudflareDNSStatus{
+			Records: []cfgatev1alpha1.DNSRecordSyncStatus{
+				{
+					Hostname: "good.example.com",
+					Type:     "CNAME",
+					Status:   "Synced",
+					RecordID: "good-id",
+					ZoneID:   "zone-1",
+				},
+				{
+					Hostname: "bad.example.invalid",
+					Type:     "CNAME",
+					Status:   "Failed",
+					Error:    "zone example.invalid not configured",
+				},
+			},
+		},
+	}
+
+	r := &CloudflareDNSReconciler{CFClient: mock}
+	if err := r.cleanupRecordsWithFallback(ctx, dns); err != nil {
+		t.Fatalf("cleanupRecordsWithFallback() error = %v", err)
+	}
+
+	if resolvedUnexpectedZone {
+		t.Fatal("cleanupRecordsWithFallback() tried to resolve an unconfigured zone for a failed, non-materialized record")
+	}
+	if len(deleted) != 1 || deleted[0] != "good-id" {
+		t.Fatalf("deleted record IDs = %#v, want only good-id", deleted)
+	}
+}
+
 func discardLogger() logr.Logger {
 	return logr.Discard()
 }

--- a/internal/controller/cloudflaredns_controller.go
+++ b/internal/controller/cloudflaredns_controller.go
@@ -1384,6 +1384,14 @@ func (r *CloudflareDNSReconciler) cleanupRecordsWithFallback(ctx context.Context
 			"ownerID", ownerID,
 		)
 		for _, statusRecord := range dns.Status.Records {
+			if statusRecord.Status == "Failed" && statusRecord.RecordID == "" && statusRecord.ZoneID == "" {
+				logger.V(1).Info("cleanup: skipping failed status record with no materialized Cloudflare record",
+					"hostname", statusRecord.Hostname,
+					"type", statusRecord.Type,
+				)
+				continue
+			}
+
 			zoneID := statusRecord.ZoneID
 			if zoneID == "" {
 				zoneName := cloudflare.ExtractZoneFromHostname(statusRecord.Hostname)

--- a/test/e2e/dns_test.go
+++ b/test/e2e/dns_test.go
@@ -985,21 +985,25 @@ var _ = Describe("CloudflareDNS E2E", Label("cloudflare"), Ordered, func() {
 			Eventually(func(g Gomega) {
 				var current cfgatev1alpha1.CloudflareDNS
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: dnsResource.Name, Namespace: dnsResource.Namespace}, &current)).To(Succeed())
-				g.Expect(current.Status.SyncedRecords).To(Equal(int32(1)))
 				g.Expect(current.Status.FailedRecords).To(Equal(int32(1)))
+				g.Expect(current.Status.SyncedRecords).To(BeNumerically(">=", 1))
 				g.Expect(findCondition(current.Status.Conditions, "RecordsSynced")).NotTo(BeNil())
 				g.Expect(findCondition(current.Status.Conditions, "RecordsSynced").Status).To(Equal(metav1.ConditionFalse))
 				g.Expect(findCondition(current.Status.Conditions, "Ready")).NotTo(BeNil())
 				g.Expect(findCondition(current.Status.Conditions, "Ready").Status).To(Equal(metav1.ConditionFalse))
 
-				var foundFailed bool
+				var foundFailed, foundSynced bool
 				for _, record := range current.Status.Records {
 					if record.Hostname == badHostname && record.Status == "Failed" {
 						foundFailed = true
 						g.Expect(record.Error).To(ContainSubstring("zone"))
 					}
+					if record.Hostname == goodHostname && record.Status == "Synced" {
+						foundSynced = true
+					}
 				}
 				g.Expect(foundFailed).To(BeTrue())
+				g.Expect(foundSynced).To(BeTrue())
 			}, DefaultTimeout, DefaultInterval).Should(Succeed())
 
 			By("Verifying the valid hostname still syncs to Cloudflare")


### PR DESCRIPTION
## Summary
- skip DNS delete-time cleanup for failed status entries that never materialized a Cloudflare record
- add a controller regression test that preserves cleanup for the valid record while ignoring the failed invalid-zone status entry
- relax the partial-sync E2E accounting assertion so it checks the expected good and bad hostnames without assuming the ordered DNS suite namespace has only one synced hostname

## Context
This fixes the release E2E failure from Actions job `70980639571`, where the partial-sync DNS spec timed out and namespace cleanup then blocked on `zone example.invalid not found` during finalizer handling.

## Test plan
- `go test ./internal/controller -run 'Test(DeleteManagedStatusRecord|CleanupRecordsWithFallback)'`
- `mise run lint`
- `bash -lc 'eval "$(ruby -e '\''require "yaml"; require "shellwords"; data = YAML.load($stdin.read) || {}; data.each { |k,v| puts "export #{k}=#{Shellwords.escape(v.to_s)}" }'\'' < <(sops -d secrets.enc.yaml))" && E2E_USE_EXISTING_CLUSTER=true CLUSTER_NAME=abaddon ginkgo -vv --procs=1 --keep-going --silence-skips --poll-progress-after=15s --focus-file=test/e2e/dns_test.go:959 ./test/e2e'`