### PR TITLE
fix: retry e2e httproute annotation updates

### DIFF
--- a/test/e2e/dns_test.go
+++ b/test/e2e/dns_test.go
@@ -525,11 +525,9 @@ var _ = Describe("CloudflareDNS E2E", Label("cloudflare"), Ordered, func() {
 				createTestService(ctx, k8sClient, serviceName, targetNamespace.Name, 8080)
 				hostname := fmt.Sprintf("%s.%s", testID("selector-"+suffix), testEnv.CloudflareZoneName)
 				route := createHTTPRoute(ctx, k8sClient, testID("route-"+suffix), targetNamespace.Name, gatewayName, []string{hostname}, serviceName, 8080)
-				if route.Annotations == nil {
-					route.Annotations = map[string]string{}
-				}
-				route.Annotations["e2e.dns/selection"] = "union"
-				Expect(k8sClient.Update(ctx, route)).To(Succeed())
+				updateHTTPRouteAnnotations(ctx, k8sClient, route.Name, route.Namespace, func(annotations map[string]string) {
+					annotations["e2e.dns/selection"] = "union"
+				})
 				return hostname
 			}
 
@@ -604,8 +602,9 @@ var _ = Describe("CloudflareDNS E2E", Label("cloudflare"), Ordered, func() {
 			hostname := fmt.Sprintf("%s.%s", testID("route-cleanup"), testEnv.CloudflareZoneName)
 			routeName := testID("route")
 			route := createHTTPRoute(ctx, k8sClient, routeName, namespace.Name, gatewayName, []string{hostname}, serviceName, 8080)
-			route.Annotations = map[string]string{"e2e.dns/cleanup": "enabled"}
-			Expect(k8sClient.Update(ctx, route)).To(Succeed())
+			route = updateHTTPRouteAnnotations(ctx, k8sClient, route.Name, route.Namespace, func(annotations map[string]string) {
+				annotations["e2e.dns/cleanup"] = "enabled"
+			})
 
 			By("Creating CloudflareDNS with deleteOnRouteRemoval enabled")
 			dnsResource := &cfgatev1alpha1.CloudflareDNS{
@@ -659,8 +658,9 @@ var _ = Describe("CloudflareDNS E2E", Label("cloudflare"), Ordered, func() {
 			hostname := fmt.Sprintf("%s.%s", testID("route-preserve"), testEnv.CloudflareZoneName)
 			routeName := testID("route")
 			route := createHTTPRoute(ctx, k8sClient, routeName, namespace.Name, gatewayName, []string{hostname}, serviceName, 8080)
-			route.Annotations = map[string]string{"e2e.dns/cleanup": "preserve"}
-			Expect(k8sClient.Update(ctx, route)).To(Succeed())
+			route = updateHTTPRouteAnnotations(ctx, k8sClient, route.Name, route.Namespace, func(annotations map[string]string) {
+				annotations["e2e.dns/cleanup"] = "preserve"
+			})
 
 			By("Creating CloudflareDNS with deleteOnRouteRemoval disabled")
 			dnsResource := &cfgatev1alpha1.CloudflareDNS{
@@ -949,8 +949,9 @@ var _ = Describe("CloudflareDNS E2E", Label("cloudflare"), Ordered, func() {
 			createTestService(ctx, k8sClient, serviceName, namespace.Name, 8080)
 			hostname := fmt.Sprintf("%s.%s", testID("recovered"), testEnv.CloudflareZoneName)
 			route := createHTTPRoute(ctx, k8sClient, testID("route"), namespace.Name, gatewayName, []string{hostname}, serviceName, 8080)
-			route.Annotations = map[string]string{"e2e.dns/recovery": "enabled"}
-			Expect(k8sClient.Update(ctx, route)).To(Succeed())
+			updateHTTPRouteAnnotations(ctx, k8sClient, route.Name, route.Namespace, func(annotations map[string]string) {
+				annotations["e2e.dns/recovery"] = "enabled"
+			})
 
 			waitForDNSReady(ctx, k8sClient, dnsResource.Name, dnsResource.Namespace, DefaultTimeout)
 			waitForDNSRecordID(ctx, cfClient, zoneID, hostname, "CNAME", DefaultTimeout)

--- a/test/e2e/gateway_route_status_test.go
+++ b/test/e2e/gateway_route_status_test.go
@@ -297,11 +297,9 @@ var _ = Describe("Gateway and HTTPRoute Status E2E", Label("cloudflare"), Ordere
 
 			service := createTestService(ctx, k8sClient, testID("svc"), namespace.Name, 8080)
 			route := createHTTPRoute(ctx, k8sClient, testID("missing-policy-route"), namespace.Name, gatewayName, []string{fmt.Sprintf("%s.example.test", testID("missing-policy"))}, service.Name, 8080)
-			if route.Annotations == nil {
-				route.Annotations = map[string]string{}
-			}
-			route.Annotations["cfgate.io/access-policy"] = "does-not-exist"
-			Expect(k8sClient.Update(ctx, route)).To(Succeed())
+			route = updateHTTPRouteAnnotations(ctx, k8sClient, route.Name, route.Namespace, func(annotations map[string]string) {
+				annotations["cfgate.io/access-policy"] = "does-not-exist"
+			})
 
 			route = waitForHTTPRouteParentCondition(ctx, k8sClient, route.Name, route.Namespace, namespace.Name, gatewayName, "AccessPolicyResolved", metav1.ConditionFalse, DefaultTimeout)
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -23,6 +23,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cfgatev1alpha1 "cfgate.io/cfgate/api/v1alpha1"
@@ -825,6 +826,24 @@ func createHTTPRoute(ctx context.Context, k8sClient client.Client, name, namespa
 
 	Expect(k8sClient.Create(ctx, hr)).To(Succeed())
 	return hr
+}
+
+// updateHTTPRouteAnnotations refetches and updates annotations with conflict retry.
+func updateHTTPRouteAnnotations(ctx context.Context, k8sClient client.Client, name, namespace string, mutate func(map[string]string)) *gatewayv1.HTTPRoute {
+	var updated gatewayv1.HTTPRoute
+	Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if err := k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &updated); err != nil {
+			return err
+		}
+		annotations := updated.Annotations
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		mutate(annotations)
+		updated.Annotations = annotations
+		return k8sClient.Update(ctx, &updated)
+	})).To(Succeed())
+	return updated.DeepCopy()
 }
 
 // createTestService creates a simple Service for testing.


### PR DESCRIPTION
## Summary
- add a shared helper that refetches HTTPRoute objects and retries annotation updates on conflict
- switch the route-annotation update sites in DNS and gateway-route E2E specs to use that helper
- remove the stale-object update race that crashed release E2E job `70983384565`

## Context
The retagged `v0.1.0-alpha.21` release E2E failed in `CloudflareDNS E2E -> should delete orphaned records when source routes are removed and deleteOnRouteRemoval=true` with:

`Operation cannot be fulfilled on httproutes.gateway.networking.k8s.io ... the object has been modified`

The failing test created an `HTTPRoute`, then immediately called `Update` on the stale object after controllers had already written status.

## Test plan
- `mise run lint`
- `go test ./test/e2e -run '^$'`
- `bash -lc 'eval "$(ruby -e '\''require "yaml"; require "shellwords"; data = YAML.load($stdin.read) || {}; data.each { |k,v| puts "export #{k}=#{Shellwords.escape(v.to_s)}" }'\'' < <(sops -d secrets.enc.yaml))" && E2E_USE_EXISTING_CLUSTER=true CLUSTER_NAME=abaddon ginkgo -vv --procs=1 --keep-going --silence-skips --poll-progress-after=15s --focus-file=test/e2e/dns_test.go:592 ./test/e2e'`