### PR TITLE
fix(cloudflared): run tunnel pods with restricted security

### DIFF
--- a/docs/cloudflare-tunnel.md
+++ b/docs/cloudflare-tunnel.md
@@ -102,6 +102,8 @@ Controls the cloudflared daemon Deployment. The controller creates a Deployment 
 
 **Metrics:** Enabled by default on port 44483. The endpoint serves Prometheus-compatible metrics at `/metrics` on each cloudflared pod. Use `podAnnotations` to configure Prometheus scraping.
 
+Generated cloudflared pods are compatible with Kubernetes `restricted` Pod Security by default. cfgate runs them as non-root, uses the runtime-default seccomp profile, disables privilege escalation, and drops all Linux capabilities.
+
 ```yaml
 spec:
   cloudflared:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -270,6 +270,10 @@ flowchart TD
 | GatewayClass not accepted | Verify `spec.gatewayClassName` references an accepted GatewayClass |
 | cloudflared pods crashing | Check pod logs: `kubectl logs -n cfgate-system deploy/cloudflared-<tunnel-name> -c cloudflared` |
 
+### Pod Security Admission rejects cloudflared pods
+
+If pod creation fails with `violates PodSecurity "restricted:latest"` and mentions `allowPrivilegeEscalation != false`, `capabilities.drop=["ALL"]`, `runAsNonRoot != true`, or `seccompProfile`, upgrade cfgate to `v0.2.0-alpha.2` or newer. Older cfgate versions can use a less restricted namespace as a temporary workaround.
+
 ---
 
 ## Stuck Finalizers

--- a/internal/cloudflared/deployment.go
+++ b/internal/cloudflared/deployment.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 
 	cfgatev1alpha1 "cfgate.io/cfgate/api/v1alpha1"
 )
@@ -96,6 +97,12 @@ func (b *DefaultBuilder) BuildDeployment(tunnel *cfgatev1alpha1.CloudflareTunnel
 					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: ptr.To(true),
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 					Containers: []corev1.Container{container},
 				},
 			},
@@ -203,6 +210,12 @@ func buildContainer(tunnel *cfgatev1alpha1.CloudflareTunnel, tokenSecretName str
 		Image:           image,
 		ImagePullPolicy: pullPolicy,
 		Args:            args,
+		SecurityContext: &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
 		Env: []corev1.EnvVar{
 			{
 				Name: TokenEnvVar,

--- a/internal/cloudflared/deployment_test.go
+++ b/internal/cloudflared/deployment_test.go
@@ -662,6 +662,28 @@ func TestBuildDeploymentExtended(t *testing.T) {
 			t.Errorf("Tolerations should be nil, got %v", deployment.Spec.Template.Spec.Tolerations)
 		}
 	})
+
+	t.Run("pod security context", func(t *testing.T) {
+		tunnel := newDeploymentTestTunnel("test")
+		deployment := builder.BuildDeployment(tunnel, "token")
+		securityContext := deployment.Spec.Template.Spec.SecurityContext
+		if securityContext == nil {
+			t.Fatal("SecurityContext should not be nil")
+			return
+		}
+		if securityContext.RunAsNonRoot == nil {
+			t.Fatal("RunAsNonRoot should not be nil")
+		}
+		if !*securityContext.RunAsNonRoot {
+			t.Error("RunAsNonRoot should be true")
+		}
+		if securityContext.SeccompProfile == nil {
+			t.Fatal("SeccompProfile should not be nil")
+		}
+		if securityContext.SeccompProfile.Type != corev1.SeccompProfileTypeRuntimeDefault {
+			t.Errorf("SeccompProfile.Type = %q, want %q", securityContext.SeccompProfile.Type, corev1.SeccompProfileTypeRuntimeDefault)
+		}
+	})
 }
 
 func TestBuildContainerExtended(t *testing.T) {
@@ -778,6 +800,33 @@ func TestBuildContainerExtended(t *testing.T) {
 		ref := container.Env[0].ValueFrom.SecretKeyRef
 		if ref.Name != "my-secret-name" {
 			t.Errorf("secret ref name = %q, want %q", ref.Name, "my-secret-name")
+		}
+	})
+
+	t.Run("security context", func(t *testing.T) {
+		container := buildContainer(newDeploymentTestTunnel("test"), "test-secret")
+		securityContext := container.SecurityContext
+		if securityContext == nil {
+			t.Fatal("SecurityContext should not be nil")
+			return
+		}
+		if securityContext.AllowPrivilegeEscalation == nil {
+			t.Fatal("AllowPrivilegeEscalation should not be nil")
+		}
+		if *securityContext.AllowPrivilegeEscalation {
+			t.Error("AllowPrivilegeEscalation should be false")
+		}
+		if securityContext.Capabilities == nil {
+			t.Fatal("Capabilities should not be nil")
+		}
+		wantDrop := []corev1.Capability{"ALL"}
+		if len(securityContext.Capabilities.Drop) != len(wantDrop) {
+			t.Fatalf("Capabilities.Drop = %v, want %v", securityContext.Capabilities.Drop, wantDrop)
+		}
+		for i, want := range wantDrop {
+			if securityContext.Capabilities.Drop[i] != want {
+				t.Errorf("Capabilities.Drop[%d] = %q, want %q", i, securityContext.Capabilities.Drop[i], want)
+			}
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- run generated cloudflared pods with restricted-compatible security contexts
- add unit coverage for pod/container security context fields
- document Pod Security Admission behavior for CloudflareTunnel users

Fixes #61.