### PR TITLE
fix(controller): preserve recreated tunnel status

### DIFF
--- a/config/crd/bases/cfgate.io_cloudflarednses.yaml
+++ b/config/crd/bases/cfgate.io_cloudflarednses.yaml
@@ -308,8 +308,9 @@ spec:
                           type: boolean
                         target:
                           description: |-
-                            Target is the CNAME target. Supports template variable {{ .TunnelDomain }}.
-                            Defaults to tunnel domain when tunnelRef is specified.
+                            Target overrides the resolved record target for this hostname.
+                            Supports template variable {{ .TunnelDomain }} when tunnelRef is used.
+                            Defaults to the resource-level resolved target when omitted.
                             Max 253: RFC 1035 section 2.3.4 FQDN presentation-format limit.
                           maxLength: 253
                           type: string

--- a/internal/controller/annotations/annotations_test.go
+++ b/internal/controller/annotations/annotations_test.go
@@ -191,10 +191,10 @@ func TestValidateOriginProtocol(t *testing.T) {
 		{"udp", true},
 		{"TCP", true},
 		{"UDP", true},
-		{"grpc", true},   // invalid (not in allowed list)
-		{"ftp", true},    // invalid
-		{"ws", true},     // invalid
-		{"wss", true},    // invalid
+		{"grpc", true}, // invalid (not in allowed list)
+		{"ftp", true},  // invalid
+		{"ws", true},   // invalid
+		{"wss", true},  // invalid
 	}
 
 	for _, tt := range tests {

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -611,6 +611,7 @@ func (r *CloudflareTunnelReconciler) syncConfiguration(ctx context.Context, tunn
 		log.Error(err, "failed to store config hash annotation")
 	} else {
 		tunnel.Annotations = annotationTunnel.Annotations
+		tunnel.ResourceVersion = annotationTunnel.ResourceVersion
 	}
 
 	tunnel.Status.ConnectedRouteCount = int32(routeCount)

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -601,12 +601,13 @@ func (r *CloudflareTunnelReconciler) syncConfiguration(ctx context.Context, tunn
 		return fmt.Errorf("failed to update tunnel configuration: %w", err)
 	}
 
-	patch := client.MergeFrom(tunnel.DeepCopy())
-	if tunnel.Annotations == nil {
-		tunnel.Annotations = make(map[string]string)
+	annotationTunnel := tunnel.DeepCopy()
+	patch := client.MergeFrom(annotationTunnel.DeepCopy())
+	if annotationTunnel.Annotations == nil {
+		annotationTunnel.Annotations = make(map[string]string)
 	}
-	tunnel.Annotations[configHashAnnotation] = desiredHash
-	if err := r.Patch(ctx, tunnel, patch); err != nil {
+	annotationTunnel.Annotations[configHashAnnotation] = desiredHash
+	if err := r.Patch(ctx, annotationTunnel, patch); err != nil {
 		log.Error(err, "failed to store config hash annotation")
 	}
 

--- a/internal/controller/cloudflaretunnel_controller.go
+++ b/internal/controller/cloudflaretunnel_controller.go
@@ -609,6 +609,8 @@ func (r *CloudflareTunnelReconciler) syncConfiguration(ctx context.Context, tunn
 	annotationTunnel.Annotations[configHashAnnotation] = desiredHash
 	if err := r.Patch(ctx, annotationTunnel, patch); err != nil {
 		log.Error(err, "failed to store config hash annotation")
+	} else {
+		tunnel.Annotations = annotationTunnel.Annotations
 	}
 
 	tunnel.Status.ConnectedRouteCount = int32(routeCount)

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -127,8 +127,12 @@ func TestSyncConfigurationPreservesStatusWhenPatchingConfigHash(t *testing.T) {
 	if err := baseClient.Get(ctx, client.ObjectKeyFromObject(storedTunnel), &current); err != nil {
 		t.Fatalf("Get() error = %v", err)
 	}
-	if current.Annotations[configHashAnnotation] == "" {
+	storedHash := current.Annotations[configHashAnnotation]
+	if storedHash == "" {
 		t.Fatal("config hash annotation was not stored")
+	}
+	if tunnel.Annotations[configHashAnnotation] != storedHash {
+		t.Fatalf("in-memory config hash = %q, want %q", tunnel.Annotations[configHashAnnotation], storedHash)
 	}
 	if current.Status.TunnelID != "old-id" {
 		t.Fatalf("stored Status.TunnelID = %q, want old-id", current.Status.TunnelID)

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -1,0 +1,162 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	cfgatev1alpha1 "cfgate.io/cfgate/api/v1alpha1"
+	"cfgate.io/cfgate/internal/cloudflare"
+	"cfgate.io/cfgate/internal/controller/annotations"
+)
+
+func TestSyncConfigurationPreservesStatusWhenPatchingConfigHash(t *testing.T) {
+	ctx := context.Background()
+	scheme := controllerTestScheme(t)
+
+	storedTunnel := &cfgatev1alpha1.CloudflareTunnel{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "edge",
+			Namespace: "default",
+		},
+		Spec: cfgatev1alpha1.CloudflareTunnelSpec{
+			Tunnel: cfgatev1alpha1.TunnelIdentity{
+				Name: "edge",
+			},
+			Cloudflare: cfgatev1alpha1.CloudflareConfig{
+				AccountID: "account",
+			},
+		},
+		Status: cfgatev1alpha1.CloudflareTunnelStatus{
+			TunnelID:     "old-id",
+			TunnelName:   "edge",
+			TunnelDomain: cloudflare.TunnelDomain("old-id"),
+			AccountID:    "account",
+		},
+	}
+	tunnel := storedTunnel.DeepCopy()
+	tunnel.Status.TunnelID = "new-id"
+	tunnel.Status.TunnelDomain = cloudflare.TunnelDomain("new-id")
+
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gateway",
+			Namespace: "default",
+			Annotations: map[string]string{
+				annotations.AnnotationTunnelRef: "default/edge",
+			},
+		},
+	}
+	servicePort := gatewayv1.PortNumber(8080)
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "route",
+			Namespace: "default",
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{
+					Name: "gateway",
+				}},
+			},
+			Hostnames: []gatewayv1.Hostname{"app.example.com"},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{
+							Name: "app",
+							Port: &servicePort,
+						},
+					},
+				}},
+			}},
+		},
+	}
+
+	baseClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&cfgatev1alpha1.CloudflareTunnel{}).
+		WithObjects(storedTunnel, gateway, route).
+		Build()
+	patchClient := &statusResettingPatchClient{Client: baseClient}
+
+	updateCalled := false
+	mockClient := cloudflare.NewMockClient()
+	mockClient.UpdateTunnelConfigurationFunc = func(_ context.Context, accountID, tunnelID string, config cloudflare.TunnelConfiguration) error {
+		updateCalled = true
+		if accountID != "account" {
+			t.Fatalf("accountID = %q, want account", accountID)
+		}
+		if tunnelID != "new-id" {
+			t.Fatalf("tunnelID = %q, want new-id", tunnelID)
+		}
+		if len(config.Ingress) == 0 || config.Ingress[0].Hostname != "app.example.com" {
+			t.Fatalf("config.Ingress = %#v, want app.example.com rule", config.Ingress)
+		}
+		return nil
+	}
+
+	reconciler := &CloudflareTunnelReconciler{
+		Client:    patchClient,
+		APIReader: baseClient,
+		CFClient:  mockClient,
+		Recorder:  &fakeEventRecorder{},
+	}
+	if err := reconciler.syncConfiguration(ctx, tunnel); err != nil {
+		t.Fatalf("syncConfiguration() error = %v", err)
+	}
+
+	if !updateCalled {
+		t.Fatal("UpdateTunnelConfiguration was not called")
+	}
+	if tunnel.Status.TunnelID != "new-id" {
+		t.Fatalf("tunnel.Status.TunnelID = %q, want new-id", tunnel.Status.TunnelID)
+	}
+	if tunnel.Status.TunnelDomain != cloudflare.TunnelDomain("new-id") {
+		t.Fatalf("tunnel.Status.TunnelDomain = %q, want %q", tunnel.Status.TunnelDomain, cloudflare.TunnelDomain("new-id"))
+	}
+	if tunnel.Status.ConnectedRouteCount != 1 {
+		t.Fatalf("tunnel.Status.ConnectedRouteCount = %d, want 1", tunnel.Status.ConnectedRouteCount)
+	}
+
+	var current cfgatev1alpha1.CloudflareTunnel
+	if err := baseClient.Get(ctx, client.ObjectKeyFromObject(storedTunnel), &current); err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if current.Annotations[configHashAnnotation] == "" {
+		t.Fatal("config hash annotation was not stored")
+	}
+	if current.Status.TunnelID != "old-id" {
+		t.Fatalf("stored Status.TunnelID = %q, want old-id", current.Status.TunnelID)
+	}
+}
+
+type statusResettingPatchClient struct {
+	client.Client
+}
+
+func (c *statusResettingPatchClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	serverStatus := cfgatev1alpha1.CloudflareTunnelStatus{}
+	hasServerStatus := false
+	if tunnel, ok := obj.(*cfgatev1alpha1.CloudflareTunnel); ok {
+		var current cfgatev1alpha1.CloudflareTunnel
+		if err := c.Get(ctx, client.ObjectKeyFromObject(tunnel), &current); err != nil {
+			return err
+		}
+		serverStatus = current.Status
+		hasServerStatus = true
+	}
+
+	if err := c.Client.Patch(ctx, obj, patch, opts...); err != nil {
+		return err
+	}
+
+	if tunnel, ok := obj.(*cfgatev1alpha1.CloudflareTunnel); ok && hasServerStatus {
+		tunnel.Status = serverStatus
+	}
+	return nil
+}

--- a/internal/controller/cloudflaretunnel_controller_test.go
+++ b/internal/controller/cloudflaretunnel_controller_test.go
@@ -134,6 +134,9 @@ func TestSyncConfigurationPreservesStatusWhenPatchingConfigHash(t *testing.T) {
 	if tunnel.Annotations[configHashAnnotation] != storedHash {
 		t.Fatalf("in-memory config hash = %q, want %q", tunnel.Annotations[configHashAnnotation], storedHash)
 	}
+	if tunnel.ResourceVersion != current.ResourceVersion {
+		t.Fatalf("in-memory ResourceVersion = %q, want %q", tunnel.ResourceVersion, current.ResourceVersion)
+	}
 	if current.Status.TunnelID != "old-id" {
 		t.Fatalf("stored Status.TunnelID = %q, want old-id", current.Status.TunnelID)
 	}

--- a/internal/controller/features/detection_test.go
+++ b/internal/controller/features/detection_test.go
@@ -61,7 +61,7 @@ func (m *mockDiscovery) withEmptyGroup(gv string) *mockDiscovery {
 
 // Group version constants used in tests.
 var (
-	gvBeta1  = schema.GroupVersion{Group: GatewayAPIGroup, Version: V1Beta1}.String()
+	gvBeta1 = schema.GroupVersion{Group: GatewayAPIGroup, Version: V1Beta1}.String()
 )
 
 // fullMock returns a mock with the optional ReferenceGrant CRD present.


### PR DESCRIPTION
## Summary
- Patch the config-hash annotation on a deep copy so Kubernetes main-resource patch responses cannot overwrite newer in-memory status.
- Add a regression test that simulates status subresource behavior after a recreated tunnel receives a new ID.

## Test plan
- go test ./internal/controller -run TestSyncConfigurationPreservesStatusWhenPatchingConfigHash -count=1
- go test ./internal/controller -count=1
- go test ./internal/cloudflared -count=1
- mise run test
- mise run lint
- mise run build
- go test ./test/e2e -run '^$' -count=1
- mise run e2e:preflight

Live local E2E was not run because the configured kind-abaddon context is unreachable and Docker/Colima is not running locally.