### PR TITLE
fix(e2e): clean stale access owner tags

### DIFF
--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -26,7 +26,7 @@ const (
 type resource struct {
 	ID   string // Cloudflare resource ID
 	Name string // Resource name (for display)
-	Type string // Resource type: tunnel, dns, access_app, service_token
+	Type string // Resource type: tunnel, dns, access_app, access_tag, service_token
 }
 
 type cleanupConfig struct {
@@ -46,11 +46,13 @@ type cleanupClient interface {
 	ListOrphanedTunnels(context.Context, string) ([]resource, error)
 	ListOrphanedDNSRecords(context.Context, string) ([]resource, error)
 	ListOrphanedAccessApplications(context.Context, string) ([]resource, error)
+	ListOrphanedAccessTags(context.Context, string) ([]resource, error)
 	ListOrphanedServiceTokens(context.Context, string) ([]resource, error)
 	ResolveZoneID(context.Context, string) (string, error)
 	DeleteTunnel(context.Context, string, string) error
 	DeleteDNSRecord(context.Context, string, string) error
 	DeleteAccessApplication(context.Context, string, string) error
+	DeleteAccessTag(context.Context, string, string) error
 	DeleteServiceToken(context.Context, string, string) error
 }
 
@@ -67,11 +69,13 @@ var (
 	listOrphanedTunnelsFn            = listOrphanedTunnels
 	listOrphanedDNSRecordsFn         = listOrphanedDNSRecords
 	listOrphanedAccessApplicationsFn = listOrphanedAccessApplications
+	listOrphanedAccessTagsFn         = listOrphanedAccessTags
 	listOrphanedServiceTokensFn      = listOrphanedServiceTokens
 	getZoneIDFn                      = getZoneID
 	deleteTunnelFn                   = deleteTunnel
 	deleteDNSRecordFn                = deleteDNSRecord
 	deleteAccessApplicationFn        = deleteAccessApplication
+	deleteAccessTagFn                = deleteAccessTag
 	deleteServiceTokenFn             = deleteServiceToken
 )
 
@@ -144,14 +148,6 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 	printScanSection(out, "Service Tokens", tokens, err)
 	summary.Found += len(tokens)
 
-	if summary.Found == 0 {
-		_, _ = fmt.Fprintln(out, "=== No orphaned E2E resources found ===")
-		return summary, nil
-	}
-
-	_, _ = fmt.Fprintf(out, "=== Found %d orphaned resources ===\n\n", summary.Found)
-	_, _ = fmt.Fprintln(out, "--- Deleting Resources ---")
-
 	deleteResources := func(resources []resource, label string, deleteFn func(resource) error) {
 		for _, res := range resources {
 			_, _ = fmt.Fprintf(out, "  Deleting %s: %s ... ", label, res.Name)
@@ -167,28 +163,51 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 		}
 	}
 
-	deleteResources(tunnels, "tunnel", func(res resource) error {
-		return client.DeleteTunnel(ctx, cfg.AccountID, res.ID)
-	})
+	if summary.Found > 0 {
+		_, _ = fmt.Fprintf(out, "=== Found %d orphaned resources ===\n\n", summary.Found)
+		_, _ = fmt.Fprintln(out, "--- Deleting Resources ---")
 
-	if cfg.ZoneName != "" && len(records) > 0 {
-		zoneID, err := client.ResolveZoneID(ctx, cfg.ZoneName)
-		if err != nil {
-			_, _ = fmt.Fprintf(out, "Warning: failed to resolve zone ID for %s: %v\n", cfg.ZoneName, err)
-		} else {
-			deleteResources(records, "DNS record", func(res resource) error {
-				return client.DeleteDNSRecord(ctx, zoneID, res.ID)
-			})
+		deleteResources(tunnels, "tunnel", func(res resource) error {
+			return client.DeleteTunnel(ctx, cfg.AccountID, res.ID)
+		})
+
+		if cfg.ZoneName != "" && len(records) > 0 {
+			zoneID, err := client.ResolveZoneID(ctx, cfg.ZoneName)
+			if err != nil {
+				_, _ = fmt.Fprintf(out, "Warning: failed to resolve zone ID for %s: %v\n", cfg.ZoneName, err)
+			} else {
+				deleteResources(records, "DNS record", func(res resource) error {
+					return client.DeleteDNSRecord(ctx, zoneID, res.ID)
+				})
+			}
 		}
+
+		deleteResources(apps, "Access application", func(res resource) error {
+			return client.DeleteAccessApplication(ctx, cfg.AccountID, res.ID)
+		})
+
+		deleteResources(tokens, "service token", func(res resource) error {
+			return client.DeleteServiceToken(ctx, cfg.AccountID, res.ID)
+		})
 	}
 
-	deleteResources(apps, "Access application", func(res resource) error {
-		return client.DeleteAccessApplication(ctx, cfg.AccountID, res.ID)
+	tags, err := client.ListOrphanedAccessTags(ctx, cfg.AccountID)
+	printScanSection(out, "Access Tags", tags, err)
+	summary.Found += len(tags)
+
+	if len(tags) > 0 && summary.Deleted+summary.Failed == 0 {
+		_, _ = fmt.Fprintf(out, "=== Found %d orphaned resources ===\n\n", summary.Found)
+		_, _ = fmt.Fprintln(out, "--- Deleting Resources ---")
+	}
+
+	deleteResources(tags, "Access tag", func(res resource) error {
+		return client.DeleteAccessTag(ctx, cfg.AccountID, res.ID)
 	})
 
-	deleteResources(tokens, "service token", func(res resource) error {
-		return client.DeleteServiceToken(ctx, cfg.AccountID, res.ID)
-	})
+	if summary.Found == 0 {
+		_, _ = fmt.Fprintln(out, "=== No orphaned E2E resources found ===")
+		return summary, nil
+	}
 
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintln(out, "=== Cleanup Summary ===")
@@ -232,6 +251,10 @@ func (c *cloudflareCleanupClient) ListOrphanedAccessApplications(ctx context.Con
 	return listOrphanedAccessApplicationsFn(ctx, c.client, accountID)
 }
 
+func (c *cloudflareCleanupClient) ListOrphanedAccessTags(ctx context.Context, accountID string) ([]resource, error) {
+	return listOrphanedAccessTagsFn(ctx, c.client, accountID)
+}
+
 func (c *cloudflareCleanupClient) ListOrphanedServiceTokens(ctx context.Context, accountID string) ([]resource, error) {
 	return listOrphanedServiceTokensFn(ctx, c.client, accountID)
 }
@@ -250,6 +273,10 @@ func (c *cloudflareCleanupClient) DeleteDNSRecord(ctx context.Context, zoneID, r
 
 func (c *cloudflareCleanupClient) DeleteAccessApplication(ctx context.Context, accountID, appID string) error {
 	return deleteAccessApplicationFn(ctx, c.client, accountID, appID)
+}
+
+func (c *cloudflareCleanupClient) DeleteAccessTag(ctx context.Context, accountID, tagName string) error {
+	return deleteAccessTagFn(ctx, c.client, accountID, tagName)
 }
 
 func (c *cloudflareCleanupClient) DeleteServiceToken(ctx context.Context, accountID, tokenID string) error {
@@ -324,6 +351,74 @@ func listOrphanedAccessApplications(ctx context.Context, client *cloudflare.Clie
 	return results, nil
 }
 
+// listOrphanedAccessTags finds unreferenced cfgate owner tags.
+func listOrphanedAccessTags(ctx context.Context, client *cloudflare.Client, accountID string) ([]resource, error) {
+	referenced := map[string]struct{}{}
+	appIter := client.ZeroTrust.Access.Applications.ListAutoPaging(ctx, zero_trust.AccessApplicationListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	for appIter.Next() {
+		for _, tag := range accessApplicationTagNames(appIter.Current().Tags) {
+			referenced[tag] = struct{}{}
+		}
+	}
+	if err := appIter.Err(); err != nil {
+		return nil, fmt.Errorf("failed to list Access applications for tag references: %w", err)
+	}
+
+	var results []resource
+	tagIter := client.ZeroTrust.Access.Tags.ListAutoPaging(ctx, zero_trust.AccessTagListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	for tagIter.Next() {
+		tag := tagIter.Current()
+		if !isCfgateOwnerTag(tag.Name) {
+			continue
+		}
+		if _, ok := referenced[tag.Name]; ok {
+			continue
+		}
+		results = append(results, resource{ID: tag.Name, Name: tag.Name, Type: "access_tag"})
+	}
+	if err := tagIter.Err(); err != nil {
+		return nil, fmt.Errorf("failed to list Access tags: %w", err)
+	}
+
+	return results, nil
+}
+
+func isCfgateOwnerTag(name string) bool {
+	const prefix = "cfgate:"
+	if len(name) != len(prefix)+28 || !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	for _, r := range name[len(prefix):] {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func accessApplicationTagNames(tags interface{}) []string {
+	switch typed := tags.(type) {
+	case nil:
+		return nil
+	case []string:
+		return typed
+	case []interface{}:
+		names := make([]string, 0, len(typed))
+		for _, tag := range typed {
+			if name, ok := tag.(string); ok {
+				names = append(names, name)
+			}
+		}
+		return names
+	default:
+		return nil
+	}
+}
+
 // listOrphanedServiceTokens finds service tokens with e2e- name prefix.
 func listOrphanedServiceTokens(ctx context.Context, client *cloudflare.Client, accountID string) ([]resource, error) {
 	var results []resource
@@ -388,6 +483,17 @@ func deleteDNSRecord(ctx context.Context, client *cloudflare.Client, zoneID, rec
 // deleteAccessApplication removes an Access application by ID.
 func deleteAccessApplication(ctx context.Context, client *cloudflare.Client, accountID, appID string) error {
 	_, err := client.ZeroTrust.Access.Applications.Delete(ctx, appID, zero_trust.AccessApplicationDeleteParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		return err
+	}
+	return nil
+}
+
+// deleteAccessTag removes an Access tag by name.
+func deleteAccessTag(ctx context.Context, client *cloudflare.Client, accountID, tagName string) error {
+	_, err := client.ZeroTrust.Access.Tags.Delete(ctx, tagName, zero_trust.AccessTagDeleteParams{
 		AccountID: cloudflare.F(accountID),
 	})
 	if err != nil && !strings.Contains(err.Error(), "not found") {

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"cfgate.io/cfgate/internal/accesstags"
+
 	cloudflare "github.com/cloudflare/cloudflare-go/v6"
 	"github.com/cloudflare/cloudflare-go/v6/dns"
 	"github.com/cloudflare/cloudflare-go/v6/option"
@@ -148,6 +150,15 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 	printScanSection(out, "Service Tokens", tokens, err)
 	summary.Found += len(tokens)
 
+	deletionStarted := false
+	startDeleting := func() {
+		if deletionStarted {
+			return
+		}
+		_, _ = fmt.Fprintln(out, "--- Deleting Resources ---")
+		deletionStarted = true
+	}
+
 	deleteResources := func(resources []resource, label string, deleteFn func(resource) error) {
 		for _, res := range resources {
 			_, _ = fmt.Fprintf(out, "  Deleting %s: %s ... ", label, res.Name)
@@ -164,9 +175,7 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 	}
 
 	if summary.Found > 0 {
-		_, _ = fmt.Fprintf(out, "=== Found %d orphaned resources ===\n\n", summary.Found)
-		_, _ = fmt.Fprintln(out, "--- Deleting Resources ---")
-
+		startDeleting()
 		deleteResources(tunnels, "tunnel", func(res resource) error {
 			return client.DeleteTunnel(ctx, cfg.AccountID, res.ID)
 		})
@@ -195,9 +204,8 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 	printScanSection(out, "Access Tags", tags, err)
 	summary.Found += len(tags)
 
-	if len(tags) > 0 && summary.Deleted+summary.Failed == 0 {
-		_, _ = fmt.Fprintf(out, "=== Found %d orphaned resources ===\n\n", summary.Found)
-		_, _ = fmt.Fprintln(out, "--- Deleting Resources ---")
+	if len(tags) > 0 {
+		startDeleting()
 	}
 
 	deleteResources(tags, "Access tag", func(res resource) error {
@@ -211,6 +219,7 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 
 	_, _ = fmt.Fprintln(out)
 	_, _ = fmt.Fprintln(out, "=== Cleanup Summary ===")
+	_, _ = fmt.Fprintf(out, "Found:   %d\n", summary.Found)
 	_, _ = fmt.Fprintf(out, "Deleted: %d\n", summary.Deleted)
 	_, _ = fmt.Fprintf(out, "Failed:  %d\n", summary.Failed)
 
@@ -358,7 +367,7 @@ func listOrphanedAccessTags(ctx context.Context, client *cloudflare.Client, acco
 		AccountID: cloudflare.F(accountID),
 	})
 	for appIter.Next() {
-		for _, tag := range accessApplicationTagNames(appIter.Current().Tags) {
+		for _, tag := range accesstags.ApplicationTagNames(appIter.Current().Tags) {
 			referenced[tag] = struct{}{}
 		}
 	}
@@ -372,7 +381,7 @@ func listOrphanedAccessTags(ctx context.Context, client *cloudflare.Client, acco
 	})
 	for tagIter.Next() {
 		tag := tagIter.Current()
-		if !isCfgateOwnerTag(tag.Name) {
+		if !accesstags.IsOwnerTag(tag.Name) {
 			continue
 		}
 		if _, ok := referenced[tag.Name]; ok {
@@ -385,38 +394,6 @@ func listOrphanedAccessTags(ctx context.Context, client *cloudflare.Client, acco
 	}
 
 	return results, nil
-}
-
-func isCfgateOwnerTag(name string) bool {
-	const prefix = "cfgate:"
-	if len(name) != len(prefix)+28 || !strings.HasPrefix(name, prefix) {
-		return false
-	}
-	for _, r := range name[len(prefix):] {
-		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
-			return false
-		}
-	}
-	return true
-}
-
-func accessApplicationTagNames(tags interface{}) []string {
-	switch typed := tags.(type) {
-	case nil:
-		return nil
-	case []string:
-		return typed
-	case []interface{}:
-		names := make([]string, 0, len(typed))
-		for _, tag := range typed {
-			if name, ok := tag.(string); ok {
-				names = append(names, name)
-			}
-		}
-		return names
-	default:
-		return nil
-	}
 }
 
 // listOrphanedServiceTokens finds service tokens with e2e- name prefix.

--- a/cmd/cleanup/main_test.go
+++ b/cmd/cleanup/main_test.go
@@ -14,18 +14,21 @@ type fakeCleanupClient struct {
 	tunnels []resource
 	records []resource
 	apps    []resource
+	tags    []resource
 	tokens  []resource
 	zoneID  string
 
 	tunnelsErr error
 	recordsErr error
 	appsErr    error
+	tagsErr    error
 	tokensErr  error
 	zoneErr    error
 
 	deleteTunnelErr map[string]error
 	deleteRecordErr map[string]error
 	deleteAppErr    map[string]error
+	deleteTagErr    map[string]error
 	deleteTokenErr  map[string]error
 }
 
@@ -106,6 +109,10 @@ func (f *fakeCleanupClient) ListOrphanedAccessApplications(context.Context, stri
 	return f.apps, f.appsErr
 }
 
+func (f *fakeCleanupClient) ListOrphanedAccessTags(context.Context, string) ([]resource, error) {
+	return f.tags, f.tagsErr
+}
+
 func (f *fakeCleanupClient) ListOrphanedServiceTokens(context.Context, string) ([]resource, error) {
 	return f.tokens, f.tokensErr
 }
@@ -133,6 +140,13 @@ func (f *fakeCleanupClient) DeleteDNSRecord(_ context.Context, _, recordID strin
 
 func (f *fakeCleanupClient) DeleteAccessApplication(_ context.Context, _, appID string) error {
 	if err := f.deleteAppErr[appID]; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *fakeCleanupClient) DeleteAccessTag(_ context.Context, _, tagName string) error {
+	if err := f.deleteTagErr[tagName]; err != nil {
 		return err
 	}
 	return nil
@@ -272,6 +286,45 @@ func TestRunCleanup(t *testing.T) {
 			t.Fatalf("output = %q, want failed tunnel deletion log", buf.String())
 		}
 	})
+
+	t.Run("deletes orphaned Access tags", func(t *testing.T) {
+		client := &fakeCleanupClient{
+			tags: []resource{{ID: "cfgate:0123456789abcdef0123456789ab", Name: "cfgate:0123456789abcdef0123456789ab", Type: "access_tag"}},
+		}
+		buf := &bytes.Buffer{}
+
+		summary, err := runCleanup(context.Background(), cfg, client, buf)
+		if err != nil {
+			t.Fatalf("runCleanup() error = %v", err)
+		}
+		if summary.Found != 1 || summary.Deleted != 1 || summary.Failed != 0 {
+			t.Fatalf("summary = %+v, want one deleted Access tag", summary)
+		}
+		if !strings.Contains(buf.String(), "Deleting Access tag: cfgate:0123456789abcdef0123456789ab ... OK") {
+			t.Fatalf("output = %q, want Access tag delete log", buf.String())
+		}
+	})
+
+	t.Run("reports Access tag deletion failures", func(t *testing.T) {
+		client := &fakeCleanupClient{
+			tags: []resource{{ID: "cfgate:0123456789abcdef0123456789ab", Name: "cfgate:0123456789abcdef0123456789ab", Type: "access_tag"}},
+			deleteTagErr: map[string]error{
+				"cfgate:0123456789abcdef0123456789ab": errors.New("tag delete failed"),
+			},
+		}
+		buf := &bytes.Buffer{}
+
+		summary, err := runCleanup(context.Background(), cfg, client, buf)
+		if err == nil || !strings.Contains(err.Error(), "cleanup failed") {
+			t.Fatalf("runCleanup() error = %v, want cleanup failure", err)
+		}
+		if summary.Failed != 1 || summary.Deleted != 0 {
+			t.Fatalf("summary = %+v, want one failed Access tag deletion", summary)
+		}
+		if len(summary.FailedResources) != 1 || summary.FailedResources[0].Type != "access_tag" {
+			t.Fatalf("FailedResources = %+v, want one access_tag resource", summary.FailedResources)
+		}
+	})
 }
 
 func TestPrintScanSection(t *testing.T) {
@@ -286,25 +339,50 @@ func TestPrintScanSection(t *testing.T) {
 	}
 }
 
+func TestIsCfgateOwnerTag(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "cfgate:0123456789abcdef0123456789ab", want: true},
+		{name: "cfgate", want: false},
+		{name: "cfgate:0123456789abcdef0123456789a", want: false},
+		{name: "cfgate:0123456789abcdef0123456789abc", want: false},
+		{name: "cfgate:0123456789abcdef0123456789az", want: false},
+		{name: "cfgate:0123456789ABCDEF0123456789AB", want: false},
+		{name: "e2e-cfgate:0123456789abcdef0123456789ab", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := isCfgateOwnerTag(tt.name); got != tt.want {
+			t.Fatalf("isCfgateOwnerTag(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestCloudflareCleanupClientDelegates(t *testing.T) {
 	origListTunnels := listOrphanedTunnelsFn
 	origListRecords := listOrphanedDNSRecordsFn
 	origListApps := listOrphanedAccessApplicationsFn
+	origListTags := listOrphanedAccessTagsFn
 	origListTokens := listOrphanedServiceTokensFn
 	origGetZoneID := getZoneIDFn
 	origDeleteTunnel := deleteTunnelFn
 	origDeleteDNS := deleteDNSRecordFn
 	origDeleteApp := deleteAccessApplicationFn
+	origDeleteTag := deleteAccessTagFn
 	origDeleteToken := deleteServiceTokenFn
 	t.Cleanup(func() {
 		listOrphanedTunnelsFn = origListTunnels
 		listOrphanedDNSRecordsFn = origListRecords
 		listOrphanedAccessApplicationsFn = origListApps
+		listOrphanedAccessTagsFn = origListTags
 		listOrphanedServiceTokensFn = origListTokens
 		getZoneIDFn = origGetZoneID
 		deleteTunnelFn = origDeleteTunnel
 		deleteDNSRecordFn = origDeleteDNS
 		deleteAccessApplicationFn = origDeleteApp
+		deleteAccessTagFn = origDeleteTag
 		deleteServiceTokenFn = origDeleteToken
 	})
 
@@ -342,6 +420,17 @@ func TestCloudflareCleanupClientDelegates(t *testing.T) {
 	gotApps, err := client.ListOrphanedAccessApplications(ctx, "account")
 	if err != nil || len(gotApps) != 1 {
 		t.Fatalf("ListOrphanedAccessApplications() = (%v, %v), want one app and nil error", gotApps, err)
+	}
+
+	listOrphanedAccessTagsFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID string) ([]resource, error) {
+		if gotCtx != ctx || accountID != "account" {
+			t.Fatalf("ListOrphanedAccessTags forwarded (%v, %q), want (%v, %q)", gotCtx, accountID, ctx, "account")
+		}
+		return []resource{{ID: "cfgate:0123456789abcdef0123456789ab"}}, nil
+	}
+	gotTags, err := client.ListOrphanedAccessTags(ctx, "account")
+	if err != nil || len(gotTags) != 1 {
+		t.Fatalf("ListOrphanedAccessTags() = (%v, %v), want one tag and nil error", gotTags, err)
 	}
 
 	listOrphanedServiceTokensFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID string) ([]resource, error) {
@@ -394,6 +483,16 @@ func TestCloudflareCleanupClientDelegates(t *testing.T) {
 	}
 	if err := client.DeleteAccessApplication(ctx, "account", "a1"); err != nil {
 		t.Fatalf("DeleteAccessApplication() error = %v", err)
+	}
+
+	deleteAccessTagFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID, tagName string) error {
+		if gotCtx != ctx || accountID != "account" || tagName != "cfgate:0123456789abcdef0123456789ab" {
+			t.Fatalf("DeleteAccessTag forwarded (%v, %q, %q), want (%v, %q, %q)", gotCtx, accountID, tagName, ctx, "account", "cfgate:0123456789abcdef0123456789ab")
+		}
+		return nil
+	}
+	if err := client.DeleteAccessTag(ctx, "account", "cfgate:0123456789abcdef0123456789ab"); err != nil {
+		t.Fatalf("DeleteAccessTag() error = %v", err)
 	}
 
 	deleteServiceTokenFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID, tokenID string) error {

--- a/cmd/cleanup/main_test.go
+++ b/cmd/cleanup/main_test.go
@@ -305,6 +305,32 @@ func TestRunCleanup(t *testing.T) {
 		}
 	})
 
+	t.Run("reports total found count after tag scan", func(t *testing.T) {
+		client := &fakeCleanupClient{
+			apps: []resource{{ID: "a1", Name: "e2e-app", Type: "access_app"}},
+			tags: []resource{
+				{ID: "cfgate:0123456789abcdef0123456789ab", Name: "cfgate:0123456789abcdef0123456789ab", Type: "access_tag"},
+				{ID: "cfgate:abcdef0123456789abcdef012345", Name: "cfgate:abcdef0123456789abcdef012345", Type: "access_tag"},
+			},
+		}
+		buf := &bytes.Buffer{}
+
+		summary, err := runCleanup(context.Background(), cfg, client, buf)
+		if err != nil {
+			t.Fatalf("runCleanup() error = %v", err)
+		}
+		if summary.Found != 3 || summary.Deleted != 3 || summary.Failed != 0 {
+			t.Fatalf("summary = %+v, want three found and deleted resources", summary)
+		}
+		output := buf.String()
+		if !strings.Contains(output, "Found:   3") {
+			t.Fatalf("output = %q, want total found count", output)
+		}
+		if strings.Contains(output, "=== Found 1 orphaned resources ===") {
+			t.Fatalf("output = %q, contains stale pre-tag found banner", output)
+		}
+	})
+
 	t.Run("reports Access tag deletion failures", func(t *testing.T) {
 		client := &fakeCleanupClient{
 			tags: []resource{{ID: "cfgate:0123456789abcdef0123456789ab", Name: "cfgate:0123456789abcdef0123456789ab", Type: "access_tag"}},
@@ -336,27 +362,6 @@ func TestPrintScanSection(t *testing.T) {
 	}
 	if !strings.Contains(output, "No orphaned dns records found") {
 		t.Fatalf("output = %q, want empty state", output)
-	}
-}
-
-func TestIsCfgateOwnerTag(t *testing.T) {
-	tests := []struct {
-		name string
-		want bool
-	}{
-		{name: "cfgate:0123456789abcdef0123456789ab", want: true},
-		{name: "cfgate", want: false},
-		{name: "cfgate:0123456789abcdef0123456789a", want: false},
-		{name: "cfgate:0123456789abcdef0123456789abc", want: false},
-		{name: "cfgate:0123456789abcdef0123456789az", want: false},
-		{name: "cfgate:0123456789ABCDEF0123456789AB", want: false},
-		{name: "e2e-cfgate:0123456789abcdef0123456789ab", want: false},
-	}
-
-	for _, tt := range tests {
-		if got := isCfgateOwnerTag(tt.name); got != tt.want {
-			t.Fatalf("isCfgateOwnerTag(%q) = %v, want %v", tt.name, got, tt.want)
-		}
 	}
 }
 

--- a/internal/accesstags/tags.go
+++ b/internal/accesstags/tags.go
@@ -1,0 +1,38 @@
+// Package accesstags contains shared helpers for cfgate Cloudflare Access tags.
+package accesstags
+
+import "strings"
+
+// IsOwnerTag reports whether name is a generated cfgate Access owner tag.
+func IsOwnerTag(name string) bool {
+	const prefix = "cfgate:"
+	if len(name) != len(prefix)+28 || !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	for _, r := range name[len(prefix):] {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// ApplicationTagNames normalizes Cloudflare SDK Access application tags.
+func ApplicationTagNames(tags interface{}) []string {
+	switch typed := tags.(type) {
+	case nil:
+		return nil
+	case []string:
+		return typed
+	case []interface{}:
+		names := make([]string, 0, len(typed))
+		for _, tag := range typed {
+			if name, ok := tag.(string); ok {
+				names = append(names, name)
+			}
+		}
+		return names
+	default:
+		return nil
+	}
+}

--- a/internal/accesstags/tags_test.go
+++ b/internal/accesstags/tags_test.go
@@ -1,0 +1,50 @@
+package accesstags
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestIsOwnerTag(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "cfgate:0123456789abcdef0123456789ab", want: true},
+		{name: "cfgate", want: false},
+		{name: "cfgate:0123456789abcdef0123456789a", want: false},
+		{name: "cfgate:0123456789abcdef0123456789abc", want: false},
+		{name: "cfgate:0123456789abcdef0123456789az", want: false},
+		{name: "cfgate:0123456789ABCDEF0123456789AB", want: false},
+		{name: "e2e-cfgate:0123456789abcdef0123456789ab", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOwnerTag(tt.name); got != tt.want {
+				t.Errorf("IsOwnerTag(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplicationTagNames(t *testing.T) {
+	tests := []struct {
+		name string
+		tags interface{}
+		want []string
+	}{
+		{name: "nil", tags: nil, want: nil},
+		{name: "strings", tags: []string{"cfgate", "owner"}, want: []string{"cfgate", "owner"}},
+		{name: "interfaces", tags: []interface{}{"cfgate", 123, "owner"}, want: []string{"cfgate", "owner"}},
+		{name: "unsupported", tags: "cfgate", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ApplicationTagNames(tt.tags); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ApplicationTagNames(%#v) = %#v, want %#v", tt.tags, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"cfgate.io/cfgate/internal/accesstags"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -578,7 +580,7 @@ func cleanOrphanedAccessTags(ctx context.Context, cfClient *cloudflare.Client) {
 		AccountID: cloudflare.F(testEnv.CloudflareAccountID),
 	})
 	for appIter.Next() {
-		for _, tag := range accessApplicationTagNames(appIter.Current().Tags) {
+		for _, tag := range accesstags.ApplicationTagNames(appIter.Current().Tags) {
 			referenced[tag] = struct{}{}
 		}
 	}
@@ -594,7 +596,7 @@ func cleanOrphanedAccessTags(ctx context.Context, cfClient *cloudflare.Client) {
 	var orphaned []string
 	for tagIter.Next() {
 		tagName := tagIter.Current().Name
-		if !isCfgateOwnerTag(tagName) {
+		if !accesstags.IsOwnerTag(tagName) {
 			continue
 		}
 		if _, ok := referenced[tagName]; ok {
@@ -621,38 +623,6 @@ func cleanOrphanedAccessTags(ctx context.Context, cfClient *cloudflare.Client) {
 		if err != nil && !strings.Contains(err.Error(), "not found") {
 			GinkgoWriter.Printf("  Warning: %s: %v\n", tagName, err)
 		}
-	}
-}
-
-func isCfgateOwnerTag(name string) bool {
-	const prefix = "cfgate:"
-	if len(name) != len(prefix)+28 || !strings.HasPrefix(name, prefix) {
-		return false
-	}
-	for _, r := range name[len(prefix):] {
-		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
-			return false
-		}
-	}
-	return true
-}
-
-func accessApplicationTagNames(tags interface{}) []string {
-	switch typed := tags.(type) {
-	case nil:
-		return nil
-	case []string:
-		return typed
-	case []interface{}:
-		names := make([]string, 0, len(typed))
-		for _, tag := range typed {
-			if name, ok := tag.(string); ok {
-				names = append(names, name)
-			}
-		}
-		return names
-	default:
-		return nil
 	}
 }
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -167,6 +167,10 @@ var _ = SynchronizedBeforeSuite(
 		// Load environment configuration.
 		testEnv = loadTestEnv()
 
+		if testEnv.CloudflareAPIToken != "" && !testEnv.SkipCleanup {
+			cleanOrphanedE2EResources()
+		}
+
 		// Find project root for CRD paths.
 		projectRoot = findProjectRoot()
 		Expect(projectRoot).NotTo(BeEmpty(), "Could not find project root")
@@ -417,9 +421,10 @@ func ensureFallbackCredentialsSecret() {
 }
 
 // cleanOrphanedE2EResources deletes all E2E test resources from Cloudflare.
-// This is the primary cleanup mechanism - runs after all tests complete.
+// This is the primary cleanup mechanism - runs before and after test execution.
 // Cleans: tunnels (e2e-*, recovery-*), DNS records (e2e-*, _cfgate.e2e-*),
-// Access applications (e2e-*), and service tokens (e2e-*).
+// Access applications (e2e-*), unreferenced cfgate owner tags, reusable Access
+// policies (e2e-*), and service tokens (e2e-*).
 func cleanOrphanedE2EResources() {
 	By("Cleaning orphaned E2E resources from Cloudflare")
 
@@ -437,6 +442,7 @@ func cleanOrphanedE2EResources() {
 
 	// Clean Access applications and reusable policies (alpha.3+).
 	cleanOrphanedAccessApplications(cleanupCtx, cfClient)
+	cleanOrphanedAccessTags(cleanupCtx, cfClient)
 	cleanOrphanedAccessPolicies(cleanupCtx, cfClient)
 
 	// Clean service tokens (alpha.3).
@@ -562,6 +568,91 @@ func cleanOrphanedAccessApplications(ctx context.Context, cfClient *cloudflare.C
 		if err != nil && !strings.Contains(err.Error(), "not found") {
 			GinkgoWriter.Printf("  Warning: %s: %v\n", app.Name, err)
 		}
+	}
+}
+
+// cleanOrphanedAccessTags deletes unreferenced cfgate owner tags.
+func cleanOrphanedAccessTags(ctx context.Context, cfClient *cloudflare.Client) {
+	referenced := map[string]struct{}{}
+	appIter := cfClient.ZeroTrust.Access.Applications.ListAutoPaging(ctx, zero_trust.AccessApplicationListParams{
+		AccountID: cloudflare.F(testEnv.CloudflareAccountID),
+	})
+	for appIter.Next() {
+		for _, tag := range accessApplicationTagNames(appIter.Current().Tags) {
+			referenced[tag] = struct{}{}
+		}
+	}
+	if err := appIter.Err(); err != nil {
+		GinkgoWriter.Printf("Warning: failed to list Access applications for tag references: %v\n", err)
+		return
+	}
+
+	tagIter := cfClient.ZeroTrust.Access.Tags.ListAutoPaging(ctx, zero_trust.AccessTagListParams{
+		AccountID: cloudflare.F(testEnv.CloudflareAccountID),
+	})
+
+	var orphaned []string
+	for tagIter.Next() {
+		tagName := tagIter.Current().Name
+		if !isCfgateOwnerTag(tagName) {
+			continue
+		}
+		if _, ok := referenced[tagName]; ok {
+			continue
+		}
+		orphaned = append(orphaned, tagName)
+	}
+
+	if err := tagIter.Err(); err != nil {
+		GinkgoWriter.Printf("Warning: failed to list Access tags: %v\n", err)
+		return
+	}
+
+	if len(orphaned) == 0 {
+		GinkgoWriter.Printf("No orphaned Access tags found\n")
+		return
+	}
+
+	GinkgoWriter.Printf("Deleting %d orphaned Access tags\n", len(orphaned))
+	for _, tagName := range orphaned {
+		_, err := cfClient.ZeroTrust.Access.Tags.Delete(ctx, tagName, zero_trust.AccessTagDeleteParams{
+			AccountID: cloudflare.F(testEnv.CloudflareAccountID),
+		})
+		if err != nil && !strings.Contains(err.Error(), "not found") {
+			GinkgoWriter.Printf("  Warning: %s: %v\n", tagName, err)
+		}
+	}
+}
+
+func isCfgateOwnerTag(name string) bool {
+	const prefix = "cfgate:"
+	if len(name) != len(prefix)+28 || !strings.HasPrefix(name, prefix) {
+		return false
+	}
+	for _, r := range name[len(prefix):] {
+		if (r < '0' || r > '9') && (r < 'a' || r > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+func accessApplicationTagNames(tags interface{}) []string {
+	switch typed := tags.(type) {
+	case nil:
+		return nil
+	case []string:
+		return typed
+	case []interface{}:
+		names := make([]string, 0, len(typed))
+		for _, tag := range typed {
+			if name, ok := tag.(string); ok {
+				names = append(names, name)
+			}
+		}
+		return names
+	default:
+		return nil
 	}
 }
 


### PR DESCRIPTION
## Summary
- add cleanup support for unreferenced cfgate Access owner tags in the standalone E2E cleanup utility
- run Cloudflare cleanup before live E2E setup so stale owner tags cannot exhaust Access tag quota before tests create applications
- sweep unreferenced owner tags after Access application cleanup while preserving base cfgate tags and tags referenced by remaining apps

## Test plan
- go test ./cmd/cleanup
- go test ./test/e2e -run '^$'
- mise run lint
- mise run build
- mise run test
- mise run test:cover