### PR TITLE
fix(security): bump Go to 1.26.3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,7 @@ cfgate/
     manager/                Controller entrypoint
     cleanup/                E2E resource cleanup utility
   internal/
+    accesstags/             Shared Access owner tag helpers
     controller/             Reconcilers (tunnel, dns, access, gateway, httproute)
     controller/annotations/ Annotation parsing and validation
     controller/context/     CRD-to-controller data wrappers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- [Go 1.26.2](https://go.dev/dl/)
+- [Go 1.26.3](https://go.dev/dl/)
 - [mise](https://mise.jdx.dev/) (task runner and tool manager)
 - [Docker](https://docs.docker.com/get-docker/) (container builds and kind clusters)
 - [sops](https://github.com/getsops/sops) + [age](https://github.com/FiloSottile/age) (secrets management)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Gateway API is the Kubernetes successor to Ingress. If you're coming from Ingres
 - **Composable CRDs for tunnels, DNS, and access.** CloudflareTunnel, CloudflareDNS, CloudflareAccessPolicy, and CloudflareAccessApplication each manage a distinct piece of Cloudflare infrastructure as Kubernetes resources. Tunnels, DNS records, reusable policies, and app bindings all live in version-controlled YAML instead of the Cloudflare dashboard.
 - **Outbound-only tunnel connections.** Cloudflare Tunnels establish outbound-only connections from the cluster to Cloudflare's edge. Services are never exposed via public IP or load balancer.
 - **Built on Gateway API.** Uses the [Gateway API](https://gateway-api.sigs.k8s.io/) standard, not a proprietary abstraction. Existing community operators use the deprecated Ingress API and lack Access policy management.
-- **Independent, composable resources.** Each CRD operates independently. Use all three together or pick the ones you need: a tunnel without DNS sync, DNS without Access, or the full stack.
+- **Independent, composable resources.** Each CRD operates independently. Use the resources together or pick the ones you need: a tunnel without DNS sync, DNS without Access, Access policies without app bindings, or the full stack.
 
 ## How It Works
 

--- a/api/v1alpha1/cloudflaredns_types.go
+++ b/api/v1alpha1/cloudflaredns_types.go
@@ -243,21 +243,21 @@ type DNSTXTRecordOwnership struct {
 //
 // Deprecated: since v0.1.0-alpha.13. The controller ignores both fields and always
 // writes a hardcoded "managed by cfgate" comment on managed DNS records. These fields
-// will be removed in v0.1.0-alpha.14. No migration is needed — the hardcoded behavior
+// will be removed in a future cleanup release. No migration is needed; the hardcoded behavior
 // is identical to the previous default values. Remove the spec.ownership.comment section
 // from your CloudflareDNS resources to silence future validation warnings.
 type DNSCommentOwnership struct {
 	// Enabled enables comment-based ownership tracking.
 	//
 	// Deprecated: since v0.1.0-alpha.13. This field is ignored. The controller always
-	// writes a "managed by cfgate" comment. Will be removed in v0.1.0-alpha.14.
+	// writes a "managed by cfgate" comment. Will be removed in a future cleanup release.
 	// +kubebuilder:default=false
 	Enabled bool `json:"enabled,omitempty"`
 
 	// Template is the comment template.
 	//
 	// Deprecated: since v0.1.0-alpha.13. This field is ignored. The controller always
-	// uses "managed by cfgate" as the comment. Will be removed in v0.1.0-alpha.14.
+	// uses "managed by cfgate" as the comment. Will be removed in a future cleanup release.
 	// +kubebuilder:default="managed by cfgate"
 	// +kubebuilder:validation:MaxLength=255
 	Template string `json:"template,omitempty"`
@@ -284,7 +284,7 @@ type DNSOwnershipConfig struct {
 
 	// Comment configures comment-based ownership.
 	//
-	// Deprecated: since v0.1.0-alpha.13. All fields are ignored. Will be removed in v0.1.0-alpha.14.
+	// Deprecated: since v0.1.0-alpha.13. All fields are ignored. Will be removed in a future cleanup release.
 	// +optional
 	Comment DNSCommentOwnership `json:"comment,omitempty"`
 }
@@ -443,7 +443,7 @@ type CloudflareDNSStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
-// CloudflareDNS is the Schema for the cloudflaredns API.
+// CloudflareDNS is the Schema for the cloudflarednses API.
 //
 // CloudflareDNS manages DNS record synchronization independently from CloudflareTunnel resources.
 // It supports two target modes: tunnel references (for tunnel-based CNAME records) and external

--- a/cmd/cleanup/doc.go
+++ b/cmd/cleanup/doc.go
@@ -9,7 +9,7 @@
 //
 // The tool ONLY deletes resources matching these patterns:
 //   - e2e-* prefix: Standard E2E test resources
-//   - e2e- in Access application domains: E2E Access hostnames
+//   - e2e-* Access application domains: E2E Access hostnames
 //   - recovery-* prefix: Test recovery scenarios
 //   - _cfgate.e2e-* prefix: DNS ownership TXT records for E2E tests
 //   - cfgate:<28 lowercase hex>: Unreferenced Access application owner tags

--- a/cmd/cleanup/doc.go
+++ b/cmd/cleanup/doc.go
@@ -9,11 +9,14 @@
 //
 // The tool ONLY deletes resources matching these patterns:
 //   - e2e-* prefix: Standard E2E test resources
+//   - e2e- in Access application domains: E2E Access hostnames
 //   - recovery-* prefix: Test recovery scenarios
 //   - _cfgate.e2e-* prefix: DNS ownership TXT records for E2E tests
+//   - cfgate:<28 lowercase hex>: Unreferenced Access application owner tags
 //
 // Production resources are never touched. The tool will not delete resources
-// that do not match the defined patterns.
+// that do not match the defined patterns, and it preserves Access owner tags
+// still referenced by any remaining Access application.
 //
 // # Resource Types
 //
@@ -21,6 +24,8 @@
 //   - Cloudflare Tunnels
 //   - DNS Records
 //   - Access Applications
+//   - Access Policies
+//   - Access Tags
 //   - Access Service Tokens
 //
 // # Required Environment Variables
@@ -35,6 +40,7 @@
 //   - Account > Cloudflare Tunnel > Edit (for tunnel cleanup)
 //   - Zone > DNS > Edit (for DNS record cleanup)
 //   - Account > Access: Apps and Policies > Edit (for Access cleanup)
+//   - Account > Access: Service Tokens > Edit (for service token cleanup)
 //
 // # Usage
 //
@@ -62,6 +68,7 @@
 //	  Deleting tunnel: e2e-tunnel-1234 ... OK
 //
 //	=== Cleanup Summary ===
+//	Found:   1
 //	Deleted: 1
 //	Failed:  0
 package main

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -381,7 +381,7 @@ func listOrphanedAccessApplications(ctx context.Context, client *cloudflare.Clie
 }
 
 func isE2EAccessApplication(name, domain string) bool {
-	return strings.HasPrefix(name, e2ePrefix) || strings.Contains(domain, e2ePrefix)
+	return strings.HasPrefix(name, e2ePrefix) || strings.HasPrefix(domain, e2ePrefix)
 }
 
 // listOrphanedAccessPolicies finds reusable Access policies with e2e- name prefix.

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -28,7 +28,7 @@ const (
 type resource struct {
 	ID   string // Cloudflare resource ID
 	Name string // Resource name (for display)
-	Type string // Resource type: tunnel, dns, access_app, access_tag, service_token
+	Type string // Resource type: tunnel, dns, access_app, access_policy, access_tag, service_token
 }
 
 type cleanupConfig struct {
@@ -48,12 +48,14 @@ type cleanupClient interface {
 	ListOrphanedTunnels(context.Context, string) ([]resource, error)
 	ListOrphanedDNSRecords(context.Context, string) ([]resource, error)
 	ListOrphanedAccessApplications(context.Context, string) ([]resource, error)
+	ListOrphanedAccessPolicies(context.Context, string) ([]resource, error)
 	ListOrphanedAccessTags(context.Context, string) ([]resource, error)
 	ListOrphanedServiceTokens(context.Context, string) ([]resource, error)
 	ResolveZoneID(context.Context, string) (string, error)
 	DeleteTunnel(context.Context, string, string) error
 	DeleteDNSRecord(context.Context, string, string) error
 	DeleteAccessApplication(context.Context, string, string) error
+	DeleteAccessPolicy(context.Context, string, string) error
 	DeleteAccessTag(context.Context, string, string) error
 	DeleteServiceToken(context.Context, string, string) error
 }
@@ -71,12 +73,14 @@ var (
 	listOrphanedTunnelsFn            = listOrphanedTunnels
 	listOrphanedDNSRecordsFn         = listOrphanedDNSRecords
 	listOrphanedAccessApplicationsFn = listOrphanedAccessApplications
+	listOrphanedAccessPoliciesFn     = listOrphanedAccessPolicies
 	listOrphanedAccessTagsFn         = listOrphanedAccessTags
 	listOrphanedServiceTokensFn      = listOrphanedServiceTokens
 	getZoneIDFn                      = getZoneID
 	deleteTunnelFn                   = deleteTunnel
 	deleteDNSRecordFn                = deleteDNSRecord
 	deleteAccessApplicationFn        = deleteAccessApplication
+	deleteAccessPolicyFn             = deleteAccessPolicy
 	deleteAccessTagFn                = deleteAccessTag
 	deleteServiceTokenFn             = deleteServiceToken
 )
@@ -146,6 +150,10 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 	printScanSection(out, "Access Applications", apps, err)
 	summary.Found += len(apps)
 
+	policies, err := client.ListOrphanedAccessPolicies(ctx, cfg.AccountID)
+	printScanSection(out, "Access Policies", policies, err)
+	summary.Found += len(policies)
+
 	tokens, err := client.ListOrphanedServiceTokens(ctx, cfg.AccountID)
 	printScanSection(out, "Service Tokens", tokens, err)
 	summary.Found += len(tokens)
@@ -193,6 +201,10 @@ func runCleanup(ctx context.Context, cfg cleanupConfig, client cleanupClient, ou
 
 		deleteResources(apps, "Access application", func(res resource) error {
 			return client.DeleteAccessApplication(ctx, cfg.AccountID, res.ID)
+		})
+
+		deleteResources(policies, "Access policy", func(res resource) error {
+			return client.DeleteAccessPolicy(ctx, cfg.AccountID, res.ID)
 		})
 
 		deleteResources(tokens, "service token", func(res resource) error {
@@ -260,6 +272,10 @@ func (c *cloudflareCleanupClient) ListOrphanedAccessApplications(ctx context.Con
 	return listOrphanedAccessApplicationsFn(ctx, c.client, accountID)
 }
 
+func (c *cloudflareCleanupClient) ListOrphanedAccessPolicies(ctx context.Context, accountID string) ([]resource, error) {
+	return listOrphanedAccessPoliciesFn(ctx, c.client, accountID)
+}
+
 func (c *cloudflareCleanupClient) ListOrphanedAccessTags(ctx context.Context, accountID string) ([]resource, error) {
 	return listOrphanedAccessTagsFn(ctx, c.client, accountID)
 }
@@ -282,6 +298,10 @@ func (c *cloudflareCleanupClient) DeleteDNSRecord(ctx context.Context, zoneID, r
 
 func (c *cloudflareCleanupClient) DeleteAccessApplication(ctx context.Context, accountID, appID string) error {
 	return deleteAccessApplicationFn(ctx, c.client, accountID, appID)
+}
+
+func (c *cloudflareCleanupClient) DeleteAccessPolicy(ctx context.Context, accountID, policyID string) error {
+	return deleteAccessPolicyFn(ctx, c.client, accountID, policyID)
 }
 
 func (c *cloudflareCleanupClient) DeleteAccessTag(ctx context.Context, accountID, tagName string) error {
@@ -339,7 +359,7 @@ func listOrphanedDNSRecords(ctx context.Context, client *cloudflare.Client, zone
 	return results, nil
 }
 
-// listOrphanedAccessApplications finds Access applications with e2e- name prefix.
+// listOrphanedAccessApplications finds Access applications with e2e- names or domains.
 func listOrphanedAccessApplications(ctx context.Context, client *cloudflare.Client, accountID string) ([]resource, error) {
 	var results []resource
 	iter := client.ZeroTrust.Access.Applications.ListAutoPaging(ctx, zero_trust.AccessApplicationListParams{
@@ -348,13 +368,38 @@ func listOrphanedAccessApplications(ctx context.Context, client *cloudflare.Clie
 
 	for iter.Next() {
 		app := iter.Current()
-		if strings.HasPrefix(app.Name, e2ePrefix) {
+		if isE2EAccessApplication(app.Name, app.Domain) {
 			results = append(results, resource{ID: app.ID, Name: app.Name, Type: "access_app"})
 		}
 	}
 
 	if err := iter.Err(); err != nil {
 		return nil, fmt.Errorf("failed to list Access applications: %w", err)
+	}
+
+	return results, nil
+}
+
+func isE2EAccessApplication(name, domain string) bool {
+	return strings.HasPrefix(name, e2ePrefix) || strings.Contains(domain, e2ePrefix)
+}
+
+// listOrphanedAccessPolicies finds reusable Access policies with e2e- name prefix.
+func listOrphanedAccessPolicies(ctx context.Context, client *cloudflare.Client, accountID string) ([]resource, error) {
+	var results []resource
+	iter := client.ZeroTrust.Access.Policies.ListAutoPaging(ctx, zero_trust.AccessPolicyListParams{
+		AccountID: cloudflare.F(accountID),
+	})
+
+	for iter.Next() {
+		policy := iter.Current()
+		if strings.HasPrefix(policy.Name, e2ePrefix) {
+			results = append(results, resource{ID: policy.ID, Name: policy.Name, Type: "access_policy"})
+		}
+	}
+
+	if err := iter.Err(); err != nil {
+		return nil, fmt.Errorf("failed to list Access policies: %w", err)
 	}
 
 	return results, nil
@@ -460,6 +505,17 @@ func deleteDNSRecord(ctx context.Context, client *cloudflare.Client, zoneID, rec
 // deleteAccessApplication removes an Access application by ID.
 func deleteAccessApplication(ctx context.Context, client *cloudflare.Client, accountID, appID string) error {
 	_, err := client.ZeroTrust.Access.Applications.Delete(ctx, appID, zero_trust.AccessApplicationDeleteParams{
+		AccountID: cloudflare.F(accountID),
+	})
+	if err != nil && !strings.Contains(err.Error(), "not found") {
+		return err
+	}
+	return nil
+}
+
+// deleteAccessPolicy removes an Access policy by ID.
+func deleteAccessPolicy(ctx context.Context, client *cloudflare.Client, accountID, policyID string) error {
+	_, err := client.ZeroTrust.Access.Policies.Delete(ctx, policyID, zero_trust.AccessPolicyDeleteParams{
 		AccountID: cloudflare.F(accountID),
 	})
 	if err != nil && !strings.Contains(err.Error(), "not found") {

--- a/cmd/cleanup/main_test.go
+++ b/cmd/cleanup/main_test.go
@@ -11,23 +11,26 @@ import (
 )
 
 type fakeCleanupClient struct {
-	tunnels []resource
-	records []resource
-	apps    []resource
-	tags    []resource
-	tokens  []resource
-	zoneID  string
+	tunnels  []resource
+	records  []resource
+	apps     []resource
+	policies []resource
+	tags     []resource
+	tokens   []resource
+	zoneID   string
 
-	tunnelsErr error
-	recordsErr error
-	appsErr    error
-	tagsErr    error
-	tokensErr  error
-	zoneErr    error
+	tunnelsErr  error
+	recordsErr  error
+	appsErr     error
+	policiesErr error
+	tagsErr     error
+	tokensErr   error
+	zoneErr     error
 
 	deleteTunnelErr map[string]error
 	deleteRecordErr map[string]error
 	deleteAppErr    map[string]error
+	deletePolicyErr map[string]error
 	deleteTagErr    map[string]error
 	deleteTokenErr  map[string]error
 }
@@ -109,6 +112,10 @@ func (f *fakeCleanupClient) ListOrphanedAccessApplications(context.Context, stri
 	return f.apps, f.appsErr
 }
 
+func (f *fakeCleanupClient) ListOrphanedAccessPolicies(context.Context, string) ([]resource, error) {
+	return f.policies, f.policiesErr
+}
+
 func (f *fakeCleanupClient) ListOrphanedAccessTags(context.Context, string) ([]resource, error) {
 	return f.tags, f.tagsErr
 }
@@ -140,6 +147,13 @@ func (f *fakeCleanupClient) DeleteDNSRecord(_ context.Context, _, recordID strin
 
 func (f *fakeCleanupClient) DeleteAccessApplication(_ context.Context, _, appID string) error {
 	if err := f.deleteAppErr[appID]; err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *fakeCleanupClient) DeleteAccessPolicy(_ context.Context, _, policyID string) error {
+	if err := f.deletePolicyErr[policyID]; err != nil {
 		return err
 	}
 	return nil
@@ -212,16 +226,18 @@ func TestRunCleanup(t *testing.T) {
 
 	t.Run("deletes resources and reports failures", func(t *testing.T) {
 		client := &fakeCleanupClient{
-			tunnels: []resource{{ID: "t1", Name: "e2e-tunnel", Type: "tunnel"}},
-			records: []resource{{ID: "r1", Name: "e2e.example.com", Type: "dns"}},
-			apps:    []resource{{ID: "a1", Name: "e2e-app", Type: "access_app"}},
-			tokens:  []resource{{ID: "s1", Name: "e2e-token", Type: "service_token"}},
-			zoneID:  "zone-1",
+			tunnels:  []resource{{ID: "t1", Name: "e2e-tunnel", Type: "tunnel"}},
+			records:  []resource{{ID: "r1", Name: "e2e.example.com", Type: "dns"}},
+			apps:     []resource{{ID: "a1", Name: "e2e-app", Type: "access_app"}},
+			policies: []resource{{ID: "p1", Name: "e2e-policy", Type: "access_policy"}},
+			tokens:   []resource{{ID: "s1", Name: "e2e-token", Type: "service_token"}},
+			zoneID:   "zone-1",
 			deleteRecordErr: map[string]error{
 				"r1": errors.New("dns delete failed"),
 			},
-			deleteAppErr:   map[string]error{},
-			deleteTokenErr: map[string]error{},
+			deleteAppErr:    map[string]error{},
+			deletePolicyErr: map[string]error{},
+			deleteTokenErr:  map[string]error{},
 		}
 		buf := &bytes.Buffer{}
 
@@ -229,11 +245,11 @@ func TestRunCleanup(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), "cleanup failed") {
 			t.Fatalf("runCleanup() error = %v, want cleanup failure", err)
 		}
-		if summary.Found != 4 {
-			t.Fatalf("Found = %d, want 4", summary.Found)
+		if summary.Found != 5 {
+			t.Fatalf("Found = %d, want 5", summary.Found)
 		}
-		if summary.Deleted != 3 {
-			t.Fatalf("Deleted = %d, want 3", summary.Deleted)
+		if summary.Deleted != 4 {
+			t.Fatalf("Deleted = %d, want 4", summary.Deleted)
 		}
 		if summary.Failed != 1 {
 			t.Fatalf("Failed = %d, want 1", summary.Failed)
@@ -305,9 +321,28 @@ func TestRunCleanup(t *testing.T) {
 		}
 	})
 
+	t.Run("deletes orphaned Access policies", func(t *testing.T) {
+		client := &fakeCleanupClient{
+			policies: []resource{{ID: "p1", Name: "e2e-policy", Type: "access_policy"}},
+		}
+		buf := &bytes.Buffer{}
+
+		summary, err := runCleanup(context.Background(), cfg, client, buf)
+		if err != nil {
+			t.Fatalf("runCleanup() error = %v", err)
+		}
+		if summary.Found != 1 || summary.Deleted != 1 || summary.Failed != 0 {
+			t.Fatalf("summary = %+v, want one deleted Access policy", summary)
+		}
+		if !strings.Contains(buf.String(), "Deleting Access policy: e2e-policy ... OK") {
+			t.Fatalf("output = %q, want Access policy delete log", buf.String())
+		}
+	})
+
 	t.Run("reports total found count after tag scan", func(t *testing.T) {
 		client := &fakeCleanupClient{
-			apps: []resource{{ID: "a1", Name: "e2e-app", Type: "access_app"}},
+			apps:     []resource{{ID: "a1", Name: "e2e-app", Type: "access_app"}},
+			policies: []resource{{ID: "p1", Name: "e2e-policy", Type: "access_policy"}},
 			tags: []resource{
 				{ID: "cfgate:0123456789abcdef0123456789ab", Name: "cfgate:0123456789abcdef0123456789ab", Type: "access_tag"},
 				{ID: "cfgate:abcdef0123456789abcdef012345", Name: "cfgate:abcdef0123456789abcdef012345", Type: "access_tag"},
@@ -319,11 +354,11 @@ func TestRunCleanup(t *testing.T) {
 		if err != nil {
 			t.Fatalf("runCleanup() error = %v", err)
 		}
-		if summary.Found != 3 || summary.Deleted != 3 || summary.Failed != 0 {
-			t.Fatalf("summary = %+v, want three found and deleted resources", summary)
+		if summary.Found != 4 || summary.Deleted != 4 || summary.Failed != 0 {
+			t.Fatalf("summary = %+v, want four found and deleted resources", summary)
 		}
 		output := buf.String()
-		if !strings.Contains(output, "Found:   3") {
+		if !strings.Contains(output, "Found:   4") {
 			t.Fatalf("output = %q, want total found count", output)
 		}
 		if strings.Contains(output, "=== Found 1 orphaned resources ===") {
@@ -351,6 +386,27 @@ func TestRunCleanup(t *testing.T) {
 			t.Fatalf("FailedResources = %+v, want one access_tag resource", summary.FailedResources)
 		}
 	})
+
+	t.Run("reports Access policy deletion failures", func(t *testing.T) {
+		client := &fakeCleanupClient{
+			policies: []resource{{ID: "p1", Name: "e2e-policy", Type: "access_policy"}},
+			deletePolicyErr: map[string]error{
+				"p1": errors.New("policy delete failed"),
+			},
+		}
+		buf := &bytes.Buffer{}
+
+		summary, err := runCleanup(context.Background(), cfg, client, buf)
+		if err == nil || !strings.Contains(err.Error(), "cleanup failed") {
+			t.Fatalf("runCleanup() error = %v, want cleanup failure", err)
+		}
+		if summary.Failed != 1 || summary.Deleted != 0 {
+			t.Fatalf("summary = %+v, want one failed Access policy deletion", summary)
+		}
+		if len(summary.FailedResources) != 1 || summary.FailedResources[0].Type != "access_policy" {
+			t.Fatalf("FailedResources = %+v, want one access_policy resource", summary.FailedResources)
+		}
+	})
 }
 
 func TestPrintScanSection(t *testing.T) {
@@ -369,24 +425,28 @@ func TestCloudflareCleanupClientDelegates(t *testing.T) {
 	origListTunnels := listOrphanedTunnelsFn
 	origListRecords := listOrphanedDNSRecordsFn
 	origListApps := listOrphanedAccessApplicationsFn
+	origListPolicies := listOrphanedAccessPoliciesFn
 	origListTags := listOrphanedAccessTagsFn
 	origListTokens := listOrphanedServiceTokensFn
 	origGetZoneID := getZoneIDFn
 	origDeleteTunnel := deleteTunnelFn
 	origDeleteDNS := deleteDNSRecordFn
 	origDeleteApp := deleteAccessApplicationFn
+	origDeletePolicy := deleteAccessPolicyFn
 	origDeleteTag := deleteAccessTagFn
 	origDeleteToken := deleteServiceTokenFn
 	t.Cleanup(func() {
 		listOrphanedTunnelsFn = origListTunnels
 		listOrphanedDNSRecordsFn = origListRecords
 		listOrphanedAccessApplicationsFn = origListApps
+		listOrphanedAccessPoliciesFn = origListPolicies
 		listOrphanedAccessTagsFn = origListTags
 		listOrphanedServiceTokensFn = origListTokens
 		getZoneIDFn = origGetZoneID
 		deleteTunnelFn = origDeleteTunnel
 		deleteDNSRecordFn = origDeleteDNS
 		deleteAccessApplicationFn = origDeleteApp
+		deleteAccessPolicyFn = origDeletePolicy
 		deleteAccessTagFn = origDeleteTag
 		deleteServiceTokenFn = origDeleteToken
 	})
@@ -425,6 +485,17 @@ func TestCloudflareCleanupClientDelegates(t *testing.T) {
 	gotApps, err := client.ListOrphanedAccessApplications(ctx, "account")
 	if err != nil || len(gotApps) != 1 {
 		t.Fatalf("ListOrphanedAccessApplications() = (%v, %v), want one app and nil error", gotApps, err)
+	}
+
+	listOrphanedAccessPoliciesFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID string) ([]resource, error) {
+		if gotCtx != ctx || accountID != "account" {
+			t.Fatalf("ListOrphanedAccessPolicies forwarded (%v, %q), want (%v, %q)", gotCtx, accountID, ctx, "account")
+		}
+		return []resource{{ID: "p1"}}, nil
+	}
+	gotPolicies, err := client.ListOrphanedAccessPolicies(ctx, "account")
+	if err != nil || len(gotPolicies) != 1 {
+		t.Fatalf("ListOrphanedAccessPolicies() = (%v, %v), want one policy and nil error", gotPolicies, err)
 	}
 
 	listOrphanedAccessTagsFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID string) ([]resource, error) {
@@ -490,6 +561,16 @@ func TestCloudflareCleanupClientDelegates(t *testing.T) {
 		t.Fatalf("DeleteAccessApplication() error = %v", err)
 	}
 
+	deleteAccessPolicyFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID, policyID string) error {
+		if gotCtx != ctx || accountID != "account" || policyID != "p1" {
+			t.Fatalf("DeleteAccessPolicy forwarded (%v, %q, %q), want (%v, %q, %q)", gotCtx, accountID, policyID, ctx, "account", "p1")
+		}
+		return nil
+	}
+	if err := client.DeleteAccessPolicy(ctx, "account", "p1"); err != nil {
+		t.Fatalf("DeleteAccessPolicy() error = %v", err)
+	}
+
 	deleteAccessTagFn = func(gotCtx context.Context, _ *cloudflare.Client, accountID, tagName string) error {
 		if gotCtx != ctx || accountID != "account" || tagName != "cfgate:0123456789abcdef0123456789ab" {
 			t.Fatalf("DeleteAccessTag forwarded (%v, %q, %q), want (%v, %q, %q)", gotCtx, accountID, tagName, ctx, "account", "cfgate:0123456789abcdef0123456789ab")
@@ -508,5 +589,28 @@ func TestCloudflareCleanupClientDelegates(t *testing.T) {
 	}
 	if err := client.DeleteServiceToken(ctx, "account", "s1"); err != nil {
 		t.Fatalf("DeleteServiceToken() error = %v", err)
+	}
+}
+
+func TestIsE2EAccessApplication(t *testing.T) {
+	tests := []struct {
+		name    string
+		appName string
+		domain  string
+		want    bool
+	}{
+		{name: "e2e name", appName: "e2e-app", domain: "app.example.com", want: true},
+		{name: "e2e domain", appName: "admin-app", domain: "e2e-admin.example.com", want: true},
+		{name: "nested e2e domain", appName: "admin-app", domain: "admin.e2e-example.com", want: true},
+		{name: "non e2e", appName: "admin-app", domain: "admin.example.com", want: false},
+		{name: "e2e outside prefix in name", appName: "admin-e2e-app", domain: "admin.example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isE2EAccessApplication(tt.appName, tt.domain); got != tt.want {
+				t.Errorf("isE2EAccessApplication(%q, %q) = %t, want %t", tt.appName, tt.domain, got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/cleanup/main_test.go
+++ b/cmd/cleanup/main_test.go
@@ -601,7 +601,7 @@ func TestIsE2EAccessApplication(t *testing.T) {
 	}{
 		{name: "e2e name", appName: "e2e-app", domain: "app.example.com", want: true},
 		{name: "e2e domain", appName: "admin-app", domain: "e2e-admin.example.com", want: true},
-		{name: "nested e2e domain", appName: "admin-app", domain: "admin.e2e-example.com", want: true},
+		{name: "e2e later in domain", appName: "admin-app", domain: "admin.e2e-example.com", want: false},
 		{name: "non e2e", appName: "admin-app", domain: "admin.example.com", want: false},
 		{name: "e2e outside prefix in name", appName: "admin-e2e-app", domain: "admin.example.com", want: false},
 	}

--- a/cmd/manager/doc.go
+++ b/cmd/manager/doc.go
@@ -9,7 +9,8 @@
 // The manager registers the following reconcilers:
 //   - CloudflareTunnelReconciler: Manages CloudflareTunnel CRDs and cloudflared deployments
 //   - CloudflareDNSReconciler: Manages CloudflareDNS CRDs and DNS record synchronization
-//   - CloudflareAccessPolicyReconciler: Manages CloudflareAccessPolicy CRDs and Access applications
+//   - CloudflareAccessPolicyReconciler: Manages reusable Access policies and service tokens
+//   - CloudflareAccessApplicationReconciler: Manages Access applications and policy links
 //   - GatewayReconciler: Validates Gateway API resources bound to tunnels
 //   - HTTPRouteReconciler: Processes HTTPRoute resources with cfgate annotations
 //

--- a/config/crd/bases/cfgate.io_cloudflarednses.yaml
+++ b/config/crd/bases/cfgate.io_cloudflarednses.yaml
@@ -37,7 +37,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: |-
-          CloudflareDNS is the Schema for the cloudflaredns API.
+          CloudflareDNS is the Schema for the cloudflarednses API.
 
           CloudflareDNS manages DNS record synchronization independently from CloudflareTunnel resources.
           It supports two target modes: tunnel references (for tunnel-based CNAME records) and external
@@ -221,7 +221,7 @@ spec:
                     description: |-
                       Comment configures comment-based ownership.
 
-                      Deprecated: since v0.1.0-alpha.13. All fields are ignored. Will be removed in v0.1.0-alpha.14.
+                      Deprecated: since v0.1.0-alpha.13. All fields are ignored. Will be removed in a future cleanup release.
                     properties:
                       enabled:
                         default: false
@@ -229,7 +229,7 @@ spec:
                           Enabled enables comment-based ownership tracking.
 
                           Deprecated: since v0.1.0-alpha.13. This field is ignored. The controller always
-                          writes a "managed by cfgate" comment. Will be removed in v0.1.0-alpha.14.
+                          writes a "managed by cfgate" comment. Will be removed in a future cleanup release.
                         type: boolean
                       template:
                         default: managed by cfgate
@@ -237,7 +237,7 @@ spec:
                           Template is the comment template.
 
                           Deprecated: since v0.1.0-alpha.13. This field is ignored. The controller always
-                          uses "managed by cfgate" as the comment. Will be removed in v0.1.0-alpha.14.
+                          uses "managed by cfgate" as the comment. Will be removed in a future cleanup release.
                         maxLength: 255
                         type: string
                     type: object

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -4,7 +4,7 @@ cfgate tests across two tiers: unit tests for pure functions and E2E tests again
 
 ## Philosophy
 
-- **Real API for E2E.** Every E2E test creates and verifies actual Cloudflare resources (tunnels, DNS records, Access applications, service tokens). No mocks, no fixtures, no VCR. Controller reconciliation patterns are incompatible with cassette approaches (attempted and removed).
+- **Real API for E2E.** Every E2E test creates and verifies actual Cloudflare resources (tunnels, DNS records, reusable Access policies, Access applications, Access owner tags, service tokens). No mocks, no fixtures, no VCR. Controller reconciliation patterns are incompatible with cassette approaches (attempted and removed).
 - **Pure-function unit tests.** Drift detection, status composition, annotation parsing, context transformation, caching, predicates, feature detection, and cloudflared builders are tested in isolation with table-driven Ginkgo specs.
 - **API state verification.** E2E tests verify that Kubernetes CRD state and Cloudflare API state converge correctly.
 
@@ -162,7 +162,9 @@ mise run e2e:cleanup
 This scans for and deletes:
 - Tunnels with `e2e-` or `recovery-` name prefix
 - DNS records containing `e2e-` or `_cfgate.e2e-` in the name
-- Access applications with `e2e-` name prefix
+- Access applications with `e2e-` name prefix or `e2e-` domain
+- Reusable Access policies with `e2e-` name prefix
+- Unreferenced Access owner tags matching `cfgate:<28 lowercase hex>`
 - Service tokens with `e2e-` name prefix
 
 Run cleanup before E2E tests to ensure a clean slate if previous runs left orphans.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -162,7 +162,7 @@ mise run e2e:cleanup
 This scans for and deletes:
 - Tunnels with `e2e-` or `recovery-` name prefix
 - DNS records containing `e2e-` or `_cfgate.e2e-` in the name
-- Access applications with `e2e-` name prefix or `e2e-` domain
+- Access applications with `e2e-` name prefix or domain prefix
 - Reusable Access policies with `e2e-` name prefix
 - Unreferenced Access owner tags matching `cfgate:<28 lowercase hex>`
 - Service tokens with `e2e-` name prefix

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -396,6 +396,12 @@ kubectl annotate cloudflareaccesspolicy my-policy cfgate.io/deletion-policy=orph
 kubectl delete cloudflareaccesspolicy my-policy
 ```
 
+```bash
+# Same for access applications
+kubectl annotate cloudflareaccessapplication my-app cfgate.io/deletion-policy=orphan
+kubectl delete cloudflareaccessapplication my-app
+```
+
 **Warning:** Orphaned resources in Cloudflare must be manually deleted via the Cloudflare dashboard or API. cfgate will not manage them again unless you re-create the Kubernetes resource with matching names.
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -371,12 +371,12 @@ Replace `cloudflaretunnel` with `cloudflaredns`, `cloudflareaccesspolicy`, or `c
 
 3. **Delete CRDs** (optional; only if you want full removal):
    ```bash
-   kubectl delete crd cloudflaretunnels.cfgate.io cloudflaredns.cfgate.io cloudflareaccesspolicies.cfgate.io
+   kubectl delete crd cloudflaretunnels.cfgate.io cloudflaredns.cfgate.io cloudflareaccesspolicies.cfgate.io cloudflareaccessapplications.cfgate.io
    ```
 
 ### Why Helm Does Not Delete CRDs by Default
 
-CRD deletion in Kubernetes cascades: deleting the CRD deletes ALL custom resources of that type across all namespaces. For cfgate, this would simultaneously delete all tunnels, DNS records, and Access policies. These resources have finalizers that need Cloudflare API access for cleanup. If CRDs are deleted before resources, finalizers cannot run, leaving orphaned Cloudflare resources with no automated cleanup path. This is a Helm-wide convention for safety.
+CRD deletion in Kubernetes cascades: deleting the CRD deletes ALL custom resources of that type across all namespaces. For cfgate, this would simultaneously delete all tunnels, DNS records, Access policies, and Access applications. These resources have finalizers that need Cloudflare API access for cleanup. If CRDs are deleted before resources, finalizers cannot run, leaving orphaned Cloudflare resources with no automated cleanup path. This is a Helm-wide convention for safety.
 
 ### Emergency: Stuck in Terminating
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module cfgate.io/cfgate
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/cloudflare/cloudflare-go/v6 v6.10.0

--- a/internal/cloudflare/dns_test.go
+++ b/internal/cloudflare/dns_test.go
@@ -421,35 +421,35 @@ func TestParseOwnershipRecord(t *testing.T) {
 		wantErr      bool
 	}{
 		{
-			name:         "alpha.3 standard",
+			name:         "structured standard",
 			content:      "heritage=cfgate,cfgate/owner=c1,cfgate/resource=hr/ns/r",
 			wantHeritage: "cfgate",
 			wantOwnerID:  "c1",
 			wantResource: "hr/ns/r",
 		},
 		{
-			name:         "alpha.3 no owner",
+			name:         "structured no owner",
 			content:      "heritage=cfgate,cfgate/resource=hr/ns/r",
 			wantHeritage: "cfgate",
 			wantOwnerID:  "",
 			wantResource: "hr/ns/r",
 		},
 		{
-			name:         "alpha.3 no resource",
+			name:         "structured no resource",
 			content:      "heritage=cfgate,cfgate/owner=c1",
 			wantHeritage: "cfgate",
 			wantOwnerID:  "c1",
 			wantResource: "",
 		},
 		{
-			name:         "alpha.3 heritage only",
+			name:         "structured heritage only",
 			content:      "heritage=cfgate",
 			wantHeritage: "cfgate",
 			wantOwnerID:  "",
 			wantResource: "",
 		},
 		{
-			name:         "alpha.3 extra fields",
+			name:         "structured extra fields",
 			content:      "heritage=cfgate,cfgate/owner=c1,cfgate/resource=r,extra=foo",
 			wantHeritage: "cfgate",
 			wantOwnerID:  "c1",

--- a/internal/controller/doc.go
+++ b/internal/controller/doc.go
@@ -6,7 +6,7 @@
 //
 // # Controllers
 //
-// The package provides five reconcilers:
+// The package provides six reconcilers:
 //
 //   - [CloudflareTunnelReconciler]: Manages CloudflareTunnel CRD lifecycle including
 //     tunnel creation/adoption, cloudflared deployment, and ingress configuration sync.
@@ -15,7 +15,10 @@
 //     hostname collection from Gateway API routes and DNS record synchronization.
 //
 //   - [CloudflareAccessPolicyReconciler]: Manages CloudflareAccessPolicy CRD lifecycle
-//     including Access Application creation and policy synchronization.
+//     including reusable Access policies and service token synchronization.
+//
+//   - [CloudflareAccessApplicationReconciler]: Manages CloudflareAccessApplication CRD
+//     lifecycle including Gateway API target binding and reusable policy links.
 //
 //   - [GatewayReconciler]: Validates Gateway resources that reference CloudflareTunnel
 //     via the cfgate.io/tunnel-ref annotation.

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,7 @@
 _.file = ".env"
 
 [tools]
-go = "1.26.2"
+go = "1.26.3"
 "aqua:kubernetes-sigs/kind" = "0.31.0"
 "aqua:kubernetes/kubernetes/kubectl" = "1.36.0"
 "aqua:kubernetes-sigs/kustomize" = "5.8.1"

--- a/test/e2e/dns_test.go
+++ b/test/e2e/dns_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 // CloudflareDNS E2E tests.
-// Tests the CloudflareDNS CRD (alpha.3 composable CRD architecture).
+// Tests the CloudflareDNS composable CRD.
 // CloudflareDNS manages DNS records independently from CloudflareTunnel.
 var _ = Describe("CloudflareDNS E2E", Label("cloudflare"), Ordered, func() {
 	var (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -547,7 +547,7 @@ func cleanOrphanedAccessApplications(ctx context.Context, cfClient *cloudflare.C
 		app := iter.Current()
 		// Match e2e-* application names and domains. Some focused Access tests use
 		// stable app names such as admin-app but e2e-* hostnames.
-		if strings.HasPrefix(app.Name, "e2e-") || strings.Contains(app.Domain, "e2e-") {
+		if strings.HasPrefix(app.Name, "e2e-") || strings.HasPrefix(app.Domain, "e2e-") {
 			orphaned = append(orphaned, struct{ ID, Name string }{app.ID, app.Name})
 		}
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -442,12 +442,12 @@ func cleanOrphanedE2EResources() {
 		cleanOrphanedDNSRecords(cleanupCtx, cfClient)
 	}
 
-	// Clean Access applications and reusable policies (alpha.3+).
+	// Clean Access applications, unreferenced owner tags, and reusable policies.
 	cleanOrphanedAccessApplications(cleanupCtx, cfClient)
 	cleanOrphanedAccessTags(cleanupCtx, cfClient)
 	cleanOrphanedAccessPolicies(cleanupCtx, cfClient)
 
-	// Clean service tokens (alpha.3).
+	// Clean service tokens.
 	cleanOrphanedServiceTokens(cleanupCtx, cfClient)
 }
 
@@ -536,7 +536,7 @@ func cleanOrphanedDNSRecords(ctx context.Context, cfClient *cloudflare.Client) {
 	}
 }
 
-// cleanOrphanedAccessApplications deletes e2e-* Access applications.
+// cleanOrphanedAccessApplications deletes e2e-* Access applications by name or domain.
 func cleanOrphanedAccessApplications(ctx context.Context, cfClient *cloudflare.Client) {
 	iter := cfClient.ZeroTrust.Access.Applications.ListAutoPaging(ctx, zero_trust.AccessApplicationListParams{
 		AccountID: cloudflare.F(testEnv.CloudflareAccountID),

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -832,8 +832,7 @@ func e2eFallbackCredentialsRef() *cfgatev1alpha1.SecretReference {
 }
 
 // createCloudflareTunnelInContext creates a CloudflareTunnel for context-level sharing.
-// Note: In alpha.3, DNS is a separate CRD (CloudflareDNS). To configure DNS records,
-// create a separate CloudflareDNS resource using createCloudflareDNS.
+// DNS records are managed by separate CloudflareDNS resources.
 func createCloudflareTunnelInContext(ctx context.Context, k8sClient client.Client, name, namespace, tunnelName string) *cfgatev1alpha1.CloudflareTunnel {
 	return createCloudflareTunnel(ctx, k8sClient, name, namespace, tunnelName)
 }
@@ -886,7 +885,7 @@ func getTunnelConfigurationFromCloudflare(ctx context.Context, cfClient *cloudfl
 }
 
 // ============================================================
-// CloudflareDNS Creation Helpers (alpha.3: separate CRD)
+// CloudflareDNS Creation Helpers
 // ============================================================
 //
 // NOTE: dns_test.go defines its own DNS helpers (createCloudflareDNSWithTunnelRef,


### PR DESCRIPTION
## Summary
- bump Go toolchain metadata from 1.26.2 to 1.26.3
- update Docker builder image to golang:1.26.3-alpine so published manager binaries use the fixed stdlib
- update contributing docs to match the new required Go patch version

## Advisories addressed
- CVE-2026-33811
- CVE-2026-33814
- CVE-2026-39820
- CVE-2026-39836
- CVE-2026-42499
- CVE-2026-39823
- CVE-2026-39825
- CVE-2026-39826

## Test plan
- mise install
- go mod tidy
- mise run lint
- mise run build
- mise run test
- mise run test:cover

Skipped local Trivy image scan and image publish; PR/release actions will cover those.