### PR TITLE
Prepare cfgate v0.2.0-alpha.4

### DIFF
--- a/api/v1alpha1/cloudflaretunnel_types.go
+++ b/api/v1alpha1/cloudflaretunnel_types.go
@@ -117,7 +117,7 @@ type CloudflaredConfig struct {
 	Replicas int32 `json:"replicas,omitempty"`
 
 	// Image is the cloudflared container image.
-	// +kubebuilder:default="ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.2"
+	// +kubebuilder:default="ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1"
 	// +kubebuilder:validation:MaxLength=255
 	Image string `json:"image,omitempty"`
 

--- a/config/crd/bases/cfgate.io_cloudflaretunnels.yaml
+++ b/config/crd/bases/cfgate.io_cloudflaretunnels.yaml
@@ -134,7 +134,7 @@ spec:
                     maxItems: 20
                     type: array
                   image:
-                    default: ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.2
+                    default: ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1
                     description: Image is the cloudflared container image.
                     maxLength: 255
                     type: string

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -131,12 +131,14 @@ mise run fe2e "deletion invariants"
 
 # Annotations
 mise run fe2e "HTTPRoute Annotations"
+mise run fe2e "origin-h2c"
 
 # Multi-CRD interactions
 mise run fe2e "Combined"
 
 # CEL validation (no Cloudflare API needed)
 mise run fe2e "CEL Validation"
+mise run fe2e "CloudflareTunnel validation"
 ```
 
 The filter argument is passed directly through as Ginkgo's `--focus` regex. It is required.
@@ -175,14 +177,14 @@ Run cleanup before E2E tests to ensure a clean slate if previous runs left orpha
 test/e2e/
   e2e_suite_test.go     # Suite setup, framework init, cleanup helpers
   helpers_test.go       # Wait functions, resource creators, CF API verifiers
-  tunnel_test.go        # CloudflareTunnel lifecycle and recovery paths (~20 specs)
+  tunnel_test.go        # CloudflareTunnel lifecycle, default cloudflared image, and recovery paths (~20 specs)
   dns_test.go           # CloudflareDNS sync, cleanup, ownership, and fallback paths (~27 specs)
   access_test.go        # CloudflareAccessPolicy/Application bindings, paths, and service tokens
-  annotations_test.go   # HTTPRoute annotation parsing and propagation (16 specs)
+  annotations_test.go   # HTTPRoute annotation parsing and remote config propagation (16 specs)
   combined_test.go      # Multi-CRD interaction and cross-resource tests (7 specs)
   gateway_route_status_test.go # Gateway / HTTPRoute negative and status coverage (7 specs)
   invariants_test.go    # Structural invariants across tunnel, DNS, Access, Gateway, and HTTPRoute (10 specs)
-  validation_test.go    # CEL validation rules, no Cloudflare API needed (12 specs)
+  validation_test.go    # CEL validation rules, no Cloudflare API needed (13 specs)
 ```
 
 #### Test Naming Convention
@@ -253,6 +255,7 @@ Never use bare `Get` followed by `Expect(Update).To(Succeed())`; the controller 
 | `waitForTunnelCondition` | Specific condition on tunnel |
 | `waitForTunnelDeleted` | Tunnel removed from K8s |
 | `waitForTunnelDeletedByIDFromCloudflare` | Tunnel removed from Cloudflare API by tunnel ID |
+| `getRawTunnelConfigurationFromCloudflare` | Remote tunnel config including SDK-unknown fields such as `h2cOrigin` |
 | `waitForDeploymentSpec` | cloudflared Deployment matches expected replicas |
 | `waitForDNSReady` | DNS status Ready=True (defined in dns_test.go) |
 | `waitForDNSDeleted` | DNS resource removed from K8s (defined in dns_test.go) |
@@ -265,6 +268,16 @@ Never use bare `Get` followed by `Expect(Update).To(Succeed())`; the controller 
 | `waitForServiceTokenDeletedFromCloudflare` | Service token removed from Cloudflare API |
 | `waitForServiceTokenSecretCreated` | Service token Secret created in K8s |
 | `waitForEventReason` | Matching Kubernetes event emitted |
+
+#### Release-Critical Surface Checks
+
+The E2E suite includes release-critical checks for behavior that is easy to regress across cfgate, Cloudflare API, and cloudflared fork boundaries:
+
+- `cfgate.io/origin-h2c` is verified against Cloudflare's remote tunnel config raw JSON so SDK-unknown fields such as `h2cOrigin` are not silently dropped.
+- CloudflareTunnel CEL validation rejects mutually exclusive `originDefaults.http2Origin` and `originDefaults.h2cOrigin`.
+- CloudflareTunnel deployment tests assert the default cloudflared image points at the inherent-design h2c fork.
+
+These checks cover control-plane config propagation. A public data-plane h2c smoke test is intentionally separate because it depends on DNS propagation and an externally reachable h2c backend.
 
 #### Resource Creators
 

--- a/docs/cloudflare-tunnel.md
+++ b/docs/cloudflare-tunnel.md
@@ -26,7 +26,7 @@ Tunnel name resolution is idempotent. The controller resolves the tunnel by name
 | `spec.cloudflare.secretRef.namespace` | `string` | *(resource namespace)* | No | Namespace of the credentials Secret. Defaults to the tunnel's namespace. Max 63 chars. |
 | `spec.cloudflare.secretKeys.apiToken` | `string` | `CLOUDFLARE_API_TOKEN` | No | Key name within the Secret for the Cloudflare API token. Max 253 chars. |
 | `spec.cloudflared.replicas` | `int32` | `2` | No | Number of cloudflared replicas. Min 1, max 10. Each replica establishes an independent connection for high availability. |
-| `spec.cloudflared.image` | `string` | `ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.2` | No | Container image for the cloudflared daemon. See [Image](#image) below. Max 255 chars. |
+| `spec.cloudflared.image` | `string` | `ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1` | No | Container image for the cloudflared daemon. See [Image](#image) below. Max 255 chars. |
 | `spec.cloudflared.imagePullPolicy` | `string` | `IfNotPresent` | No | Image pull policy. One of: `Always`, `Never`, `IfNotPresent`. |
 | `spec.cloudflared.protocol` | `string` | `auto` | No | Tunnel transport protocol. One of: `auto`, `quic`, `http2`. |
 | `spec.cloudflared.resources` | `corev1.ResourceRequirements` | *none* | No | Resource requests and limits for cloudflared containers. Standard Kubernetes resource spec. |
@@ -135,7 +135,7 @@ spec:
 
 #### Image
 
-The default image is `ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.2`, a fork of [cloudflare/cloudflared](https://github.com/cloudflare/cloudflared) maintained at [inherent-design/cloudflared](https://github.com/inherent-design/cloudflared). The fork adds `h2cOrigin` support for HTTP/2 cleartext origin connections; upstream cloudflared does not support this feature ([cloudflare/cloudflared#1304](https://github.com/cloudflare/cloudflared/issues/1304)).
+The default image is `ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1`, a fork of [cloudflare/cloudflared](https://github.com/cloudflare/cloudflared) maintained at [inherent-design/cloudflared](https://github.com/inherent-design/cloudflared). The fork adds `h2cOrigin` support for HTTP/2 cleartext origin connections; upstream cloudflared does not support this feature ([cloudflare/cloudflared#1304](https://github.com/cloudflare/cloudflared/issues/1304)).
 
 Users who do not need h2c can override the image to upstream:
 

--- a/internal/cloudflare/client_impl.go
+++ b/internal/cloudflare/client_impl.go
@@ -640,7 +640,11 @@ func (c *clientImpl) CreateAccessApplication(ctx context.Context, accountID stri
 		return nil, fmt.Errorf("failed to create access application: %w", err)
 	}
 
-	return applicationFromNewResponse(result), nil
+	app, err := applicationFromNewResponse(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert created access application: %w", err)
+	}
+	return app, nil
 }
 
 // GetAccessApplication retrieves an Access application by ID.
@@ -655,7 +659,11 @@ func (c *clientImpl) GetAccessApplication(ctx context.Context, accountID, appID 
 		return nil, fmt.Errorf("failed to get access application: %w", err)
 	}
 
-	return applicationFromGetResponse(result), nil
+	app, err := applicationFromGetResponse(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert access application: %w", err)
+	}
+	return app, nil
 }
 
 // UpdateAccessApplication updates an existing Access application.
@@ -711,7 +719,11 @@ func (c *clientImpl) UpdateAccessApplication(ctx context.Context, accountID, app
 		return nil, fmt.Errorf("failed to update access application: %w", err)
 	}
 
-	return applicationFromUpdateResponse(result), nil
+	app, err := applicationFromUpdateResponse(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert updated access application: %w", err)
+	}
+	return app, nil
 }
 
 func accessApplicationDestinationURIs(params ApplicationParams) []string {
@@ -793,7 +805,13 @@ func (c *clientImpl) ListAccessApplications(ctx context.Context, accountID strin
 
 	for page.Next() {
 		app := page.Current()
-		apps = append(apps, *applicationFromListResponse(&app))
+		converted, err := applicationFromListResponse(&app)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert listed access application: %w", err)
+		}
+		if converted != nil {
+			apps = append(apps, *converted)
+		}
 	}
 
 	if err := page.Err(); err != nil {

--- a/internal/cloudflare/client_test.go
+++ b/internal/cloudflare/client_test.go
@@ -2,8 +2,13 @@ package cloudflare
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	cf "github.com/cloudflare/cloudflare-go/v6"
+	"github.com/cloudflare/cloudflare-go/v6/option"
 	"github.com/cloudflare/cloudflare-go/v6/zero_trust"
 )
 
@@ -124,6 +129,88 @@ func TestAccessApplicationPolicyLinkParams(t *testing.T) {
 	}
 }
 
+func TestClientAccessApplicationConversionErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		response   string
+		call       func(context.Context, *clientImpl) error
+		wantPrefix string
+	}{
+		{
+			name:     "create",
+			method:   http.MethodPost,
+			path:     "/accounts/account/access/apps",
+			response: malformedAccessApplicationEnvelope(),
+			call: func(ctx context.Context, client *clientImpl) error {
+				_, err := client.CreateAccessApplication(ctx, "account", ApplicationParams{Name: "app", Domain: "app.example.com"})
+				return err
+			},
+			wantPrefix: "failed to convert created access application",
+		},
+		{
+			name:     "get",
+			method:   http.MethodGet,
+			path:     "/accounts/account/access/apps/app-1",
+			response: malformedAccessApplicationEnvelope(),
+			call: func(ctx context.Context, client *clientImpl) error {
+				_, err := client.GetAccessApplication(ctx, "account", "app-1")
+				return err
+			},
+			wantPrefix: "failed to convert access application",
+		},
+		{
+			name:     "update",
+			method:   http.MethodPut,
+			path:     "/accounts/account/access/apps/app-1",
+			response: malformedAccessApplicationEnvelope(),
+			call: func(ctx context.Context, client *clientImpl) error {
+				_, err := client.UpdateAccessApplication(ctx, "account", "app-1", ApplicationParams{Name: "app", Domain: "app.example.com"})
+				return err
+			},
+			wantPrefix: "failed to convert updated access application",
+		},
+		{
+			name:     "list",
+			method:   http.MethodGet,
+			path:     "/accounts/account/access/apps",
+			response: malformedAccessApplicationListEnvelope(),
+			call: func(ctx context.Context, client *clientImpl) error {
+				_, err := client.ListAccessApplications(ctx, "account")
+				return err
+			},
+			wantPrefix: "failed to convert listed access application",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := testClientImpl(t, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != tt.method {
+					t.Fatalf("method = %s, want %s", r.Method, tt.method)
+				}
+				if r.URL.Path != tt.path {
+					t.Fatalf("path = %s, want %s", r.URL.Path, tt.path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			})
+
+			err := tt.call(context.Background(), client)
+			if err == nil {
+				t.Fatal("access application conversion error = nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantPrefix) {
+				t.Fatalf("error = %q, want prefix %q", err.Error(), tt.wantPrefix)
+			}
+			if !strings.Contains(err.Error(), "unmarshal access application extras") {
+				t.Fatalf("error = %q, want unmarshal context", err.Error())
+			}
+		})
+	}
+}
+
 func TestMockClientUnstubbedAccessMethods(t *testing.T) {
 	mock := NewMockClient()
 	ctx := context.Background()
@@ -187,4 +274,44 @@ func TestMockClientUnstubbedAccessMethods(t *testing.T) {
 	if token, err := mock.RefreshServiceToken(ctx, "account", "token"); token != nil || err != nil {
 		t.Fatalf("RefreshServiceToken() = (%+v, %v), want nil nil", token, err)
 	}
+}
+
+func testClientImpl(t *testing.T, handler http.HandlerFunc) *clientImpl {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	return &clientImpl{api: cf.NewClient(
+		option.WithAPIToken("test-token"),
+		option.WithBaseURL(server.URL),
+	)}
+}
+
+func malformedAccessApplicationEnvelope() string {
+	return `{
+		"success": true,
+		"errors": [],
+		"messages": [],
+		"result": {
+			"id": "app-1",
+			"aud": "aud-1",
+			"name": "app",
+			"domain": "app.example.com",
+			"type": "self_hosted",
+			"tags": 1
+		}
+	}`
+}
+
+func malformedAccessApplicationListEnvelope() string {
+	return `{
+		"result": [{
+			"id": "app-1",
+			"aud": "aud-1",
+			"name": "app",
+			"domain": "app.example.com",
+			"type": "self_hosted",
+			"tags": 1
+		}],
+		"result_info": {"page": 1, "per_page": 20}
+	}`
 }

--- a/internal/cloudflare/convert.go
+++ b/internal/cloudflare/convert.go
@@ -3,6 +3,7 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	cf "github.com/cloudflare/cloudflare-go/v6"
@@ -234,9 +235,9 @@ func approvalGroupsToAPI(groups []ApprovalGroupParam) []zero_trust.ApprovalGroup
 // =============================================================================
 
 // applicationFromNewResponse converts AccessApplicationNewResponse to AccessApplication.
-func applicationFromNewResponse(resp *zero_trust.AccessApplicationNewResponse) *AccessApplication {
+func applicationFromNewResponse(resp *zero_trust.AccessApplicationNewResponse) (*AccessApplication, error) {
 	if resp == nil {
-		return nil
+		return nil, nil
 	}
 
 	// Use flat fields directly from response - no union extraction needed for common fields
@@ -275,15 +276,17 @@ func applicationFromNewResponse(resp *zero_trust.AccessApplicationNewResponse) *
 		len(resp.CORSHeaders.AllowedOrigins) > 0 || resp.CORSHeaders.MaxAge > 0 {
 		app.CORSHeaders = corsHeadersFromSDK(&resp.CORSHeaders)
 	}
-	applyApplicationExtras(app, resp.JSON.RawJSON())
+	if err := applyApplicationExtras(app, resp.JSON.RawJSON()); err != nil {
+		return nil, fmt.Errorf("parse access application create response extras: %w", err)
+	}
 
-	return app
+	return app, nil
 }
 
 // applicationFromGetResponse converts AccessApplicationGetResponse to AccessApplication.
-func applicationFromGetResponse(resp *zero_trust.AccessApplicationGetResponse) *AccessApplication {
+func applicationFromGetResponse(resp *zero_trust.AccessApplicationGetResponse) (*AccessApplication, error) {
 	if resp == nil {
-		return nil
+		return nil, nil
 	}
 
 	app := &AccessApplication{
@@ -320,15 +323,17 @@ func applicationFromGetResponse(resp *zero_trust.AccessApplicationGetResponse) *
 		len(resp.CORSHeaders.AllowedOrigins) > 0 || resp.CORSHeaders.MaxAge > 0 {
 		app.CORSHeaders = corsHeadersFromSDK(&resp.CORSHeaders)
 	}
-	applyApplicationExtras(app, resp.JSON.RawJSON())
+	if err := applyApplicationExtras(app, resp.JSON.RawJSON()); err != nil {
+		return nil, fmt.Errorf("parse access application get response extras: %w", err)
+	}
 
-	return app
+	return app, nil
 }
 
 // applicationFromUpdateResponse converts AccessApplicationUpdateResponse to AccessApplication.
-func applicationFromUpdateResponse(resp *zero_trust.AccessApplicationUpdateResponse) *AccessApplication {
+func applicationFromUpdateResponse(resp *zero_trust.AccessApplicationUpdateResponse) (*AccessApplication, error) {
 	if resp == nil {
-		return nil
+		return nil, nil
 	}
 
 	app := &AccessApplication{
@@ -365,15 +370,17 @@ func applicationFromUpdateResponse(resp *zero_trust.AccessApplicationUpdateRespo
 		len(resp.CORSHeaders.AllowedOrigins) > 0 || resp.CORSHeaders.MaxAge > 0 {
 		app.CORSHeaders = corsHeadersFromSDK(&resp.CORSHeaders)
 	}
-	applyApplicationExtras(app, resp.JSON.RawJSON())
+	if err := applyApplicationExtras(app, resp.JSON.RawJSON()); err != nil {
+		return nil, fmt.Errorf("parse access application update response extras: %w", err)
+	}
 
-	return app
+	return app, nil
 }
 
 // applicationFromListResponse converts AccessApplicationListResponse to AccessApplication.
-func applicationFromListResponse(resp *zero_trust.AccessApplicationListResponse) *AccessApplication {
+func applicationFromListResponse(resp *zero_trust.AccessApplicationListResponse) (*AccessApplication, error) {
 	if resp == nil {
-		return nil
+		return nil, nil
 	}
 
 	app := &AccessApplication{
@@ -410,14 +417,16 @@ func applicationFromListResponse(resp *zero_trust.AccessApplicationListResponse)
 		len(resp.CORSHeaders.AllowedOrigins) > 0 || resp.CORSHeaders.MaxAge > 0 {
 		app.CORSHeaders = corsHeadersFromSDK(&resp.CORSHeaders)
 	}
-	applyApplicationExtras(app, resp.JSON.RawJSON())
+	if err := applyApplicationExtras(app, resp.JSON.RawJSON()); err != nil {
+		return nil, fmt.Errorf("parse access application list response extras: %w", err)
+	}
 
-	return app
+	return app, nil
 }
 
-func applyApplicationExtras(app *AccessApplication, raw string) {
+func applyApplicationExtras(app *AccessApplication, raw string) error {
 	if app == nil || raw == "" {
-		return
+		return nil
 	}
 	var extra struct {
 		Tags         []string `json:"tags"`
@@ -431,7 +440,7 @@ func applyApplicationExtras(app *AccessApplication, raw string) {
 		} `json:"policies"`
 	}
 	if err := json.Unmarshal([]byte(raw), &extra); err != nil {
-		return
+		return fmt.Errorf("unmarshal access application extras: %w", err)
 	}
 	app.Tags = extra.Tags
 	for _, destination := range extra.Destinations {
@@ -447,6 +456,7 @@ func applyApplicationExtras(app *AccessApplication, raw string) {
 			})
 		}
 	}
+	return nil
 }
 
 // =============================================================================

--- a/internal/cloudflare/convert_test.go
+++ b/internal/cloudflare/convert_test.go
@@ -271,8 +271,9 @@ func TestApplicationResponseConverters(t *testing.T) {
 		},
 	}
 
-	assertApplication(t, applicationFromNewResponse(&resp))
-	assertApplication(t, applicationFromGetResponse(&zero_trust.AccessApplicationGetResponse{
+	app, err := applicationFromNewResponse(&resp)
+	assertApplication(t, mustApplication(t, app, err))
+	app, err = applicationFromGetResponse(&zero_trust.AccessApplicationGetResponse{
 		ID:                          resp.ID,
 		AUD:                         resp.AUD,
 		Name:                        resp.Name,
@@ -295,8 +296,9 @@ func TestApplicationResponseConverters(t *testing.T) {
 		CustomNonIdentityDenyURL:    resp.CustomNonIdentityDenyURL,
 		ReadServiceTokensFromHeader: resp.ReadServiceTokensFromHeader,
 		CORSHeaders:                 resp.CORSHeaders,
-	}))
-	assertApplication(t, applicationFromUpdateResponse(&zero_trust.AccessApplicationUpdateResponse{
+	})
+	assertApplication(t, mustApplication(t, app, err))
+	app, err = applicationFromUpdateResponse(&zero_trust.AccessApplicationUpdateResponse{
 		ID:                          resp.ID,
 		AUD:                         resp.AUD,
 		Name:                        resp.Name,
@@ -319,8 +321,9 @@ func TestApplicationResponseConverters(t *testing.T) {
 		CustomNonIdentityDenyURL:    resp.CustomNonIdentityDenyURL,
 		ReadServiceTokensFromHeader: resp.ReadServiceTokensFromHeader,
 		CORSHeaders:                 resp.CORSHeaders,
-	}))
-	assertApplication(t, applicationFromListResponse(&zero_trust.AccessApplicationListResponse{
+	})
+	assertApplication(t, mustApplication(t, app, err))
+	app, err = applicationFromListResponse(&zero_trust.AccessApplicationListResponse{
 		ID:                          resp.ID,
 		AUD:                         resp.AUD,
 		Name:                        resp.Name,
@@ -343,17 +346,26 @@ func TestApplicationResponseConverters(t *testing.T) {
 		CustomNonIdentityDenyURL:    resp.CustomNonIdentityDenyURL,
 		ReadServiceTokensFromHeader: resp.ReadServiceTokensFromHeader,
 		CORSHeaders:                 resp.CORSHeaders,
-	}))
+	})
+	assertApplication(t, mustApplication(t, app, err))
 
-	if applicationFromNewResponse(nil) != nil || applicationFromGetResponse(nil) != nil ||
-		applicationFromUpdateResponse(nil) != nil || applicationFromListResponse(nil) != nil {
-		t.Fatal("nil application response converted to non-nil app")
+	if app, err := applicationFromNewResponse(nil); app != nil || err != nil {
+		t.Fatalf("applicationFromNewResponse(nil) = (%#v, %v), want nil nil", app, err)
+	}
+	if app, err := applicationFromGetResponse(nil); app != nil || err != nil {
+		t.Fatalf("applicationFromGetResponse(nil) = (%#v, %v), want nil nil", app, err)
+	}
+	if app, err := applicationFromUpdateResponse(nil); app != nil || err != nil {
+		t.Fatalf("applicationFromUpdateResponse(nil) = (%#v, %v), want nil nil", app, err)
+	}
+	if app, err := applicationFromListResponse(nil); app != nil || err != nil {
+		t.Fatalf("applicationFromListResponse(nil) = (%#v, %v), want nil nil", app, err)
 	}
 }
 
 func TestApplyApplicationExtras(t *testing.T) {
 	app := &AccessApplication{}
-	applyApplicationExtras(app, `{
+	if err := applyApplicationExtras(app, `{
 		"tags":["cfgate","owner"],
 		"destinations":[
 			{"type":"public","uri":"app.example.com"},
@@ -361,7 +373,9 @@ func TestApplyApplicationExtras(t *testing.T) {
 			{"type":"public","uri":""}
 		],
 		"policies":[{"id":"policy-1","precedence":3},{"id":"","precedence":9}]
-	}`)
+	}`); err != nil {
+		t.Fatalf("applyApplicationExtras() error = %v", err)
+	}
 	if !reflect.DeepEqual(app.Tags, []string{"cfgate", "owner"}) {
 		t.Fatalf("Tags = %#v", app.Tags)
 	}
@@ -371,11 +385,18 @@ func TestApplyApplicationExtras(t *testing.T) {
 	if !reflect.DeepEqual(app.Policies, []ApplicationPolicyLink{{ID: "policy-1", Precedence: 3}}) {
 		t.Fatalf("Policies = %#v", app.Policies)
 	}
-	applyApplicationExtras(app, `bad-json`)
+	if err := applyApplicationExtras(app, `bad-json`); err == nil {
+		t.Fatal("applyApplicationExtras() malformed JSON error = nil")
+	}
 	if !reflect.DeepEqual(app.Tags, []string{"cfgate", "owner"}) {
 		t.Fatalf("malformed JSON changed app: %#v", app.Tags)
 	}
-	applyApplicationExtras(nil, `{"tags":["ignored"]}`)
+	if err := applyApplicationExtras(nil, `{"tags":["ignored"]}`); err != nil {
+		t.Fatalf("applyApplicationExtras(nil) error = %v", err)
+	}
+	if err := applyApplicationExtras(app, ""); err != nil {
+		t.Fatalf("applyApplicationExtras(empty) error = %v", err)
+	}
 }
 
 func TestPolicyAndGroupResponseConverters(t *testing.T) {
@@ -498,6 +519,17 @@ func assertApplication(t *testing.T, app *AccessApplication) {
 		!reflect.DeepEqual(app.CORSHeaders.AllowedHeaders, []string{"Authorization"}) {
 		t.Fatalf("CORSHeaders = %+v", app.CORSHeaders)
 	}
+}
+
+func mustApplication(t *testing.T, app *AccessApplication, err error) *AccessApplication {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("application converter error = %v", err)
+	}
+	if app == nil {
+		t.Fatal("application converter returned nil app")
+	}
+	return app
 }
 
 func assertPolicy(t *testing.T, policy *AccessPolicy) {

--- a/internal/cloudflared/deployment.go
+++ b/internal/cloudflared/deployment.go
@@ -17,7 +17,7 @@ import (
 const (
 	// DefaultImage is the default cloudflared container image.
 	// Points to the inherent-design fork which includes h2c origin support.
-	DefaultImage = "ghcr.io/inherent-design/cloudflared:2026.3.0-h2c.2"
+	DefaultImage = "ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1"
 
 	// DefaultMetricsPort is the default port for cloudflared metrics.
 	DefaultMetricsPort = 2000

--- a/internal/controller/cloudflareaccessapplication_controller.go
+++ b/internal/controller/cloudflareaccessapplication_controller.go
@@ -912,8 +912,8 @@ func deleteAccessApplicationOwnerTag(
 	app *cfgatev1alpha1.CloudflareAccessApplication,
 ) error {
 	tag := accessApplicationOwnerTag(app)
-	if tag == accessApplicationTag {
-		return nil
+	if !strings.HasPrefix(tag, accessApplicationTag+":") {
+		return fmt.Errorf("refusing to delete non-owner Access tag %q", tag)
 	}
 	if err := accessService.Client().DeleteAccessTag(ctx, accountID, tag); err != nil {
 		return fmt.Errorf("delete Access application owner tag %s: %w", tag, err)

--- a/internal/controller/cloudflareaccessapplication_controller_test.go
+++ b/internal/controller/cloudflareaccessapplication_controller_test.go
@@ -79,6 +79,17 @@ func TestValidateAccessApplicationPath(t *testing.T) {
 	}
 }
 
+func TestAccessApplicationOwnerTagIsScoped(t *testing.T) {
+	app := appWithFinalizer("app", "app")
+	tag := accessApplicationOwnerTag(app)
+	if tag == accessApplicationTag {
+		t.Fatalf("accessApplicationOwnerTag() = %q, want owner-scoped tag", tag)
+	}
+	if !strings.HasPrefix(tag, accessApplicationTag+":") {
+		t.Fatalf("accessApplicationOwnerTag() = %q, want %q prefix", tag, accessApplicationTag+":")
+	}
+}
+
 func TestDeleteStaleAccessApplications(t *testing.T) {
 	deleted := []string{}
 	mock := cloudflare.NewMockClient()

--- a/test/e2e/annotations_test.go
+++ b/test/e2e/annotations_test.go
@@ -1178,6 +1178,25 @@ SIb3DQEBCwUAA0EA+test+certificate+data+here==
 			By("Verifying tunnel ConfigurationSynced condition")
 			waitForTunnelCondition(ctx, k8sClient, sharedTunnel.Name, sharedTunnel.Namespace, "ConfigurationSynced", metav1.ConditionTrue, DefaultTimeout)
 
+			By("Verifying Cloudflare remote config enables h2cOrigin")
+			Eventually(func(g Gomega) {
+				config, err := getRawTunnelConfigurationFromCloudflare(ctx, cfClient, testEnv.CloudflareAccountID, sharedTunnel.Status.TunnelID)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				ingress, ok := findRawTunnelIngress(config, hostname)
+				g.Expect(ok).To(BeTrue(), "expected ingress rule for %s", hostname)
+				g.Expect(ingress.Service).To(Equal(fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", svcName, namespace.Name)))
+
+				h2cOrigin, ok := rawOriginRequestBool(ingress.OriginRequest, "h2cOrigin")
+				g.Expect(ok).To(BeTrue(), "expected h2cOrigin in originRequest")
+				g.Expect(h2cOrigin).To(BeTrue())
+
+				http2Origin, ok := rawOriginRequestBool(ingress.OriginRequest, "http2Origin")
+				if ok {
+					g.Expect(http2Origin).To(BeFalse())
+				}
+			}, DefaultTimeout, DefaultInterval).Should(Succeed())
+
 			By("Testing with origin-h2c=false")
 			routeName2 := testID("route-noh2c")
 			hostname2 := fmt.Sprintf("%s.%s", testID("noh2c"), testEnv.CloudflareZoneName)
@@ -1227,6 +1246,21 @@ SIb3DQEBCwUAA0EA+test+certificate+data+here==
 				}
 				return r2.Annotations["cfgate.io/origin-h2c"] == "false"
 			}, ShortTimeout, DefaultInterval).Should(BeTrue())
+
+			By("Verifying Cloudflare remote config leaves h2cOrigin disabled")
+			Eventually(func(g Gomega) {
+				config, err := getRawTunnelConfigurationFromCloudflare(ctx, cfClient, testEnv.CloudflareAccountID, sharedTunnel.Status.TunnelID)
+				g.Expect(err).NotTo(HaveOccurred())
+
+				ingress, ok := findRawTunnelIngress(config, hostname2)
+				g.Expect(ok).To(BeTrue(), "expected ingress rule for %s", hostname2)
+				g.Expect(ingress.Service).To(Equal(fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", svcName, namespace.Name)))
+
+				h2cOrigin, ok := rawOriginRequestBool(ingress.OriginRequest, "h2cOrigin")
+				if ok {
+					g.Expect(h2cOrigin).To(BeFalse())
+				}
+			}, DefaultTimeout, DefaultInterval).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -882,6 +883,58 @@ func getTunnelConfigurationFromCloudflare(ctx context.Context, cfClient *cloudfl
 		return nil, fmt.Errorf("failed to get tunnel configuration: %w", err)
 	}
 	return config, nil
+}
+
+type rawTunnelConfiguration struct {
+	Config rawTunnelConfig `json:"config"`
+}
+
+type rawTunnelConfig struct {
+	Ingress       []rawTunnelIngress `json:"ingress"`
+	OriginRequest map[string]any     `json:"originRequest,omitempty"`
+}
+
+type rawTunnelIngress struct {
+	Hostname      string         `json:"hostname"`
+	Path          string         `json:"path,omitempty"`
+	Service       string         `json:"service"`
+	OriginRequest map[string]any `json:"originRequest,omitempty"`
+}
+
+func getRawTunnelConfigurationFromCloudflare(ctx context.Context, cfClient *cloudflare.Client, accountID, tunnelID string) (*rawTunnelConfiguration, error) {
+	config, err := getTunnelConfigurationFromCloudflare(ctx, cfClient, accountID, tunnelID)
+	if err != nil {
+		return nil, err
+	}
+
+	raw := config.JSON.RawJSON()
+	if raw == "" {
+		return nil, fmt.Errorf("tunnel configuration response did not include raw JSON")
+	}
+
+	var parsed rawTunnelConfiguration
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse raw tunnel configuration: %w", err)
+	}
+	return &parsed, nil
+}
+
+func findRawTunnelIngress(config *rawTunnelConfiguration, hostname string) (*rawTunnelIngress, bool) {
+	for i := range config.Config.Ingress {
+		if config.Config.Ingress[i].Hostname == hostname {
+			return &config.Config.Ingress[i], true
+		}
+	}
+	return nil, false
+}
+
+func rawOriginRequestBool(originRequest map[string]any, key string) (bool, bool) {
+	raw, ok := originRequest[key]
+	if !ok {
+		return false, false
+	}
+	value, ok := raw.(bool)
+	return value, ok
 }
 
 // ============================================================

--- a/test/e2e/tunnel_test.go
+++ b/test/e2e/tunnel_test.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	cfgatev1alpha1 "cfgate.io/cfgate/api/v1alpha1"
+	"cfgate.io/cfgate/internal/cloudflared"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
@@ -79,6 +80,8 @@ var _ = Describe("CloudflareTunnel E2E", Label("cloudflare"), func() {
 			deploymentName := fmt.Sprintf("%s-cloudflared", tunnel.Name)
 			deployment := waitForDeploymentSpec(ctx, k8sClient, deploymentName, namespace.Name, 1, DefaultTimeout)
 			Expect(deployment).NotTo(BeNil())
+			Expect(deployment.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+			Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(cloudflared.DefaultImage))
 
 			// Store for subsequent tests if needed.
 			sharedTunnel = tunnel

--- a/test/e2e/validation_test.go
+++ b/test/e2e/validation_test.go
@@ -33,6 +33,36 @@ var _ = Describe("CEL Validation E2E", func() {
 		}
 	})
 
+	Context("CloudflareTunnel validation", func() {
+		It("rejects mutually exclusive h2c and HTTP/2 origin defaults", func() {
+			tunnel := &cfgatev1alpha1.CloudflareTunnel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testID("h2c-http2"),
+					Namespace: namespace.Name,
+				},
+				Spec: cfgatev1alpha1.CloudflareTunnelSpec{
+					Tunnel: cfgatev1alpha1.TunnelIdentity{
+						Name: testID("h2c-http2"),
+					},
+					Cloudflare: cfgatev1alpha1.CloudflareConfig{
+						AccountID: validationAccountID(),
+						SecretRef: cfgatev1alpha1.SecretRef{
+							Name: "cloudflare-credentials",
+						},
+					},
+					OriginDefaults: cfgatev1alpha1.OriginDefaults{
+						HTTP2Origin: true,
+						H2cOrigin:   true,
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, tunnel)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("http2Origin and h2cOrigin are mutually exclusive"))
+		})
+	})
+
 	Context("CloudflareAccessPolicy validation", func() {
 		It("rejects reusable policy with no include rules", func() {
 			policy := validReusablePolicy(testID("no-include"), namespace.Name)


### PR DESCRIPTION
## Summary

- Prepare cfgate `v0.2.0-alpha.4` release surface.
- Bump default cloudflared h2c fork image to `ghcr.io/inherent-design/cloudflared:2026.5.0-h2c.1`.
- Strengthen h2c e2e coverage by verifying Cloudflare remote tunnel config preserves `h2cOrigin` raw JSON.
- Add CloudflareTunnel CEL coverage for `http2Origin` / `h2cOrigin` mutual exclusion and document release-critical e2e surface checks.

## Tests

```bash
mise run test
E2E_PROCS=1 mise run e2e:filter 'origin-h2c|CloudflareTunnel validation|default cloudflared fork image|create tunnel in Cloudflare when CloudflareTunnel CR is created'
git diff --check
```

Full e2e passed before this test expansion; focused e2e passed after.